### PR TITLE
ci: add PR workflow for format, check, and tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,64 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "28"
+          gleam-version: "1.15.4"
+          rebar3-version: "3"
+
+      - name: Format all packages
+        run: |
+          for pkg in shared server client; do
+            (cd "$pkg" && gleam format src test)
+          done
+
+      - name: Commit formatting changes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          if ! git diff --cached --quiet; then
+            git commit -m "style: auto-format Gleam code"
+            git push
+          fi
+
+  check:
+    needs: format
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [shared, server, client]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "28"
+          gleam-version: "1.15.4"
+          rebar3-version: "3"
+
+      - name: Type check
+        working-directory: ${{ matrix.package }}
+        run: gleam check
+
+      - name: Run tests
+        working-directory: ${{ matrix.package }}
+        run: gleam test

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Based on official Gleam deployment guide + Lustre fullstack docs
 
 ARG ERLANG_VERSION=28.3.1
-ARG GLEAM_VERSION=v1.14.0
+ARG GLEAM_VERSION=v1.15.4
 
 FROM ghcr.io/gleam-lang/gleam:${GLEAM_VERSION}-scratch AS gleam
 


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` modeled on m4reko/orkestra: on PRs to
main, it auto-formats Gleam code and commits the diff back to the PR
branch, then type-checks and tests each package in a matrix (shared,
server, client; examples/client is skipped as it's a reference demo).

Bumps GLEAM_VERSION in Dockerfile from v1.14.0 to v1.15.4 so the build
environment matches CI. Erlang/OTP stays at 28.3.1.

https://claude.ai/code/session_01PPsJSETKmZBzsBzHHyiMy8