### PR TITLE
feat: make activities list a little more coherent

### DIFF
--- a/bump-ui-webc.sh
+++ b/bump-ui-webc.sh
@@ -20,7 +20,7 @@ sed -i.bak -E "s|@scouterna/ui-webc@[0-9]+\.[0-9]+\.[0-9]+|@scouterna/ui-webc@${
   client/gleam.toml
 rm client/gleam.toml.bak
 
-sed -i.bak -E "s|const scouterna_ui_webc_version = \"[0-9]+\.[0-9]+\.[0-9]+\"|pub const ui_webc_version = \"${VERSION}\"|" \
+sed -i.bak -E "s|(const scouterna_ui_webc_version = \")[0-9]+\.[0-9]+\.[0-9]+(\")|\1${VERSION}\2|" \
   server/src/server/web.gleam
 rm server/src/server/web.gleam.bak
 

--- a/client/bun.lock
+++ b/client/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "j26booking_client",
@@ -8,7 +7,7 @@
         "@fontsource-variable/source-sans-3": "^5.2.9",
       },
       "devDependencies": {
-        "@scouterna/tailwind-theme": "^0.0.5",
+        "@scouterna/tailwind-theme": "^0.0.6",
       },
     },
   },
@@ -19,9 +18,9 @@
 
     "@isaacs/brace-expansion": ["@isaacs/brace-expansion@5.0.0", "", { "dependencies": { "@isaacs/balanced-match": "^4.0.1" } }, "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA=="],
 
-    "@scouterna/design-tokens": ["@scouterna/design-tokens@0.0.6", "", { "dependencies": { "glob": "^13.0.0" } }, "sha512-wgqjEkTiSv+mfnpYBHkIpArRuZotZMJles+F4vhgBxsFO3p6t++jbIrp7IHh4BzsF9Du4HdTnzmqlFsCirSXag=="],
+    "@scouterna/design-tokens": ["@scouterna/design-tokens@0.0.7", "", { "dependencies": { "glob": "^13.0.0" } }, "sha512-7HT8/ltcczFmQVxYyU+fHZ8LsMa1KvDe80wshIOdilqS0hBTzaZtatnLwwRYytayfMMVX0oyP1HNfC46tkpDbQ=="],
 
-    "@scouterna/tailwind-theme": ["@scouterna/tailwind-theme@0.0.5", "", { "dependencies": { "@scouterna/design-tokens": "0.0.6" } }, "sha512-4zh2xpvNuAlBRv5SzIgbm9h4KyQ+QOtpbbLapLyWAMtCLIXM6dsGBvQeQ52s1Q6uzrqO25KLD43+L/FBV10Obw=="],
+    "@scouterna/tailwind-theme": ["@scouterna/tailwind-theme@0.0.6", "", { "dependencies": { "@scouterna/design-tokens": "0.0.7" } }, "sha512-6TX7nprndr/lHdq/AdPxMYbs3hhqWdEkROTeKbt0y6My44WKY/v4EqwUkYuMYyJWrI8C61rdAazq1llZU1aOqw=="],
 
     "glob": ["glob@13.0.0", "", { "dependencies": { "minimatch": "^10.1.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA=="],
 

--- a/client/gleam.toml
+++ b/client/gleam.toml
@@ -31,11 +31,11 @@ lustre_dev_tools = { git = "https://github.com/m4reko/lustre-dev-tools", ref = "
 
 [tools.lustre.html]
 stylesheets = [
-    { href = "https://cdn.jsdelivr.net/npm/@scouterna/ui-webc@4.4.2/dist/ui-webc/ui-webc.css" },
+    { href = "https://cdn.jsdelivr.net/npm/@scouterna/ui-webc@4.4.4/dist/ui-webc/ui-webc.css" },
     { href = "https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&display=swap" },
 ]
 scripts = [
-    { src = "https://cdn.jsdelivr.net/npm/@scouterna/ui-webc@4.4.2/dist/esm/ui-webc.js", type = "module" },
+    { src = "https://cdn.jsdelivr.net/npm/@scouterna/ui-webc@4.4.4/dist/esm/ui-webc.js", type = "module" },
 ]
 link = [
     { href = "https://fonts.googleapis.com", rel = "preconnect" },

--- a/client/gleam.toml
+++ b/client/gleam.toml
@@ -31,11 +31,11 @@ lustre_dev_tools = { git = "https://github.com/m4reko/lustre-dev-tools", ref = "
 
 [tools.lustre.html]
 stylesheets = [
-    { href = "https://cdn.jsdelivr.net/npm/@scouterna/ui-webc@4.3.4/dist/ui-webc/ui-webc.css" },
+    { href = "https://cdn.jsdelivr.net/npm/@scouterna/ui-webc@4.4.2/dist/ui-webc/ui-webc.css" },
     { href = "https://fonts.googleapis.com/css2?family=Source+Sans+3:ital,wght@0,200..900;1,200..900&display=swap" },
 ]
 scripts = [
-    { src = "https://cdn.jsdelivr.net/npm/@scouterna/ui-webc@4.3.4/dist/esm/ui-webc.js", type = "module" },
+    { src = "https://cdn.jsdelivr.net/npm/@scouterna/ui-webc@4.4.2/dist/esm/ui-webc.js", type = "module" },
 ]
 link = [
     { href = "https://fonts.googleapis.com", rel = "preconnect" },

--- a/client/package.json
+++ b/client/package.json
@@ -4,6 +4,6 @@
     "@fontsource-variable/source-sans-3": "^5.2.9"
   },
   "devDependencies": {
-    "@scouterna/tailwind-theme": "^0.0.5"
+    "@scouterna/tailwind-theme": "^0.0.6"
   }
 }

--- a/client/src/client.gleam
+++ b/client/src/client.gleam
@@ -1660,34 +1660,36 @@ fn view_activities_list(
 ) -> Element(Msg) {
   let t = fn(key) { g18n.translate(translator, key) }
 
-  html.div([attribute.class("flex flex-col gap-3 p-4")], [
+  html.div([attribute.class("flex flex-col")], [
     view_list_top_bar(translator, filters, summaries),
     case filters.more_open {
       True -> view_more_filters_panel(translator, filters)
       False -> element.none()
     },
-    case summaries {
-      NotAsked | Loading -> component.scout_loader(t("activity.loading"))
-      Failed(err) ->
-        html.div([attribute.class("py-6 flex flex-col items-center gap-3")], [
-          component.error_banner(err),
-          component.scout_button_action(
-            t("list.retry"),
-            "primary",
-            UserClickedRetryLoad,
-          ),
-        ])
-      Loaded([]) ->
-        html.div([attribute.class("py-6 text-center flex flex-col gap-3")], [
-          html.p([], [element.text("No activities yet.")]),
-        ])
-      Loaded(items) ->
-        view_grouped_activities(
-          translator,
-          to_card_items(items, statuses, spots),
-          filters,
-        )
-    },
+    html.div([attribute.class("flex flex-col gap-3 mt-3")], [
+      case summaries {
+        NotAsked | Loading -> component.scout_loader(t("activity.loading"))
+        Failed(err) ->
+          html.div([attribute.class("py-6 flex flex-col items-center gap-3")], [
+            component.error_banner(err),
+            component.scout_button_action(
+              t("list.retry"),
+              "primary",
+              UserClickedRetryLoad,
+            ),
+          ])
+        Loaded([]) ->
+          html.div([attribute.class("py-6 text-center flex flex-col gap-3")], [
+            html.p([], [element.text("No activities yet.")]),
+          ])
+        Loaded(items) ->
+          view_grouped_activities(
+            translator,
+            to_card_items(items, statuses, spots),
+            filters,
+          )
+      },
+    ]),
   ])
 }
 
@@ -1705,7 +1707,7 @@ fn view_list_top_bar(
   html.div(
     [
       attribute.class(
-        "flex flex-col gap-2 bg-white rounded-lg border border-gray-200 p-3",
+        "flex flex-col gap-2 bg-white border-b border-gray-200 p-3",
       ),
     ],
     [
@@ -1803,8 +1805,13 @@ fn view_more_filters_panel(
   filters: ListFilters,
 ) -> Element(Msg) {
   let t = fn(key) { g18n.translate(translator, key) }
-  component.scout_card([
-    html.div([attribute.class("flex flex-col gap-3 p-2")], [
+  html.div(
+    [
+      attribute.class(
+        "bg-white border-b border-gray-200 p-3 flex flex-col gap-3",
+      ),
+    ],
+    [
       html.div([attribute.class("flex flex-col gap-2")], [
         html.h4([attribute.class("text-body-sm font-semibold")], [
           element.text(t("list.filter.audience_label")),
@@ -1835,8 +1842,8 @@ fn view_more_filters_panel(
           }),
         ),
       ]),
-    ]),
-  ])
+    ],
+  )
 }
 
 fn view_grouped_activities(
@@ -1873,7 +1880,7 @@ fn view_grouped_activities(
       let today = date_of(now_ts)
       let now_bucket = current_bucket()
       html.div(
-        [attribute.class("flex flex-col gap-4")],
+        [attribute.class("flex flex-col gap-4 px-3 pb-4")],
         list.map(groups, fn(group) {
           let #(#(date, bucket), items) = group
           let is_current = date == today && bucket == now_bucket
@@ -2173,7 +2180,7 @@ fn view_activity_detail_loaded(
       // Content
       [
         attribute.class(
-          "z-10 bg-white border-t border-gray-200 flex-1 flex flex-col p-4 gap-4",
+          "z-10 bg-white border-t border-gray-200 flex-1 flex flex-col p-3 gap-4",
         ),
       ],
       [

--- a/client/src/client.gleam
+++ b/client/src/client.gleam
@@ -2159,6 +2159,15 @@ fn view_activity_detail_loaded(
       False,
     )
   html.div([attribute.class("flex flex-col")], [
+    component.scout_drawer(
+      case booking {
+        BookingOpen(_, _, _) | BookingSubmitting(_) -> True
+        BookingClosed | UnbookConfirming(_) | UnbookSubmitting(_) -> False
+      },
+      booking_drawer_heading(translator, booking),
+      UserClickedCancelBooking,
+      [view_booking_form_section(translator, booking)],
+    ),
     case activity.location {
       Some(location) ->
         html.div(
@@ -2283,10 +2292,24 @@ fn view_activity_detail_loaded(
             element.text(activity.description),
           ]),
         ]),
-        view_booking_form_section(translator, booking),
       ],
     ),
   ])
+}
+
+/// Heading for the booking drawer, based on whether the user is creating a
+/// new booking or changing an existing one. Empty when the drawer is closed.
+fn booking_drawer_heading(
+  translator: Translator,
+  booking: BookingFormState,
+) -> String {
+  case booking {
+    BookingOpen(_, _, BookingNew) | BookingSubmitting(BookingNew) ->
+      g18n.translate(translator, "activity.book")
+    BookingOpen(_, _, BookingEdit(_)) | BookingSubmitting(BookingEdit(_)) ->
+      g18n.translate(translator, "booking.change")
+    BookingClosed | UnbookConfirming(_) | UnbookSubmitting(_) -> ""
+  }
 }
 
 /// Splits the detail-page actions into a `#(primary, secondary)` pair so the
@@ -2299,11 +2322,6 @@ fn view_detail_actions(
   booking: BookingFormState,
 ) -> #(Element(Msg), Element(Msg)) {
   case booked, booking {
-    // While the booking form is open or submitting, hide the action row —
-    // the form itself provides Submit/Cancel.
-    _, BookingOpen(_, _, _) -> #(element.none(), element.none())
-    _, BookingSubmitting(_) -> #(element.none(), element.none())
-
     // Booked activity: ask the user to confirm before deleting their booking.
     True, UnbookConfirming(_) -> #(
       component.scout_button_action(
@@ -2323,8 +2341,10 @@ fn view_detail_actions(
       element.none(),
     )
 
-    // Booked, no special state: offer "Ändra bokning" + "Avboka".
-    True, BookingClosed -> #(
+    // Booked: offer "Ändra bokning" + "Avboka" — kept visible even while the
+    // booking drawer is open/submitting, since the drawer no longer hides
+    // the row behind it.
+    True, _ -> #(
       component.scout_button_action(
         g18n.translate(translator, "booking.change"),
         "primary",
@@ -2373,53 +2393,51 @@ fn view_booking_form_section(
         |> UserSubmittedBookingForm
       }
       html.form([event.on_submit(submitted)], [
-        component.scout_card([
-          html.div([attribute.class("flex flex-col gap-2")], [
-            case submit_error {
-              Some(err) -> component.error_banner(err)
-              None -> element.none()
-            },
-            component.scout_form_field(
-              form,
-              g18n.translate(translator, "booking.responsible_name"),
-              "text",
-              "responsible_name",
+        html.div([attribute.class("flex flex-col gap-2")], [
+          case submit_error {
+            Some(err) -> component.error_banner(err)
+            None -> element.none()
+          },
+          component.scout_form_field(
+            form,
+            g18n.translate(translator, "booking.responsible_name"),
+            "text",
+            "responsible_name",
+          ),
+          component.scout_form_field(
+            form,
+            g18n.translate(translator, "booking.phone_number"),
+            "tel",
+            "phone_number",
+          ),
+          component.scout_form_field(
+            form,
+            g18n.translate(translator, "booking.group_free_text"),
+            "text",
+            "group_free_text",
+          ),
+          component.scout_form_field(
+            form,
+            g18n.translate(translator, "booking.participant_count"),
+            "number",
+            "participant_count",
+          ),
+          html.div([attribute.class("flex gap-2 justify-end")], [
+            component.scout_button_action(
+              g18n.translate(translator, "booking.cancel"),
+              "outlined",
+              UserClickedCancelBooking,
             ),
-            component.scout_form_field(
-              form,
-              g18n.translate(translator, "booking.phone_number"),
-              "tel",
-              "phone_number",
+            element.element(
+              "scout-button",
+              [
+                attribute.attribute("variant", "primary"),
+                attribute.attribute("type", "submit"),
+              ],
+              [
+                element.text(g18n.translate(translator, "booking.submit")),
+              ],
             ),
-            component.scout_form_field(
-              form,
-              g18n.translate(translator, "booking.group_free_text"),
-              "text",
-              "group_free_text",
-            ),
-            component.scout_form_field(
-              form,
-              g18n.translate(translator, "booking.participant_count"),
-              "number",
-              "participant_count",
-            ),
-            html.div([attribute.class("flex gap-2 justify-end")], [
-              component.scout_button_action(
-                g18n.translate(translator, "booking.cancel"),
-                "outlined",
-                UserClickedCancelBooking,
-              ),
-              element.element(
-                "scout-button",
-                [
-                  attribute.attribute("variant", "primary"),
-                  attribute.attribute("type", "submit"),
-                ],
-                [
-                  element.text(g18n.translate(translator, "booking.submit")),
-                ],
-              ),
-            ]),
           ]),
         ]),
       ])

--- a/client/src/component.gleam
+++ b/client/src/component.gleam
@@ -208,7 +208,6 @@ pub fn filter_pill_icon(
     "scout-button",
     [
       attribute.attribute("variant", variant),
-      attribute.attribute("size", "small"),
       attribute.attribute("icon", icon_svg),
       attribute.attribute("icon-only", ""),
       attribute.attribute("aria-label", aria_label),
@@ -221,13 +220,18 @@ pub fn filter_pill_icon(
 pub fn filter_chip(label: String, selected: Bool, msg: msg) -> Element(msg) {
   let base = "px-3 py-1 rounded-full text-body-sm border cursor-pointer "
   let class = case selected {
-    True -> base <> "bg-blue-100 border-blue-500 text-blue-900"
+    True -> base <> "bg-background-brand-base border-transparent text-white"
     False -> base <> "bg-white border-gray-300 text-gray-800"
+  }
+  let aria_pressed = case selected {
+    True -> "true"
+    False -> "false"
   }
   html.button(
     [
       attribute.type_("button"),
       attribute.class(class),
+      attribute.aria_pressed(aria_pressed),
       event.on_click(msg),
     ],
     [element.text(label)],

--- a/client/src/component.gleam
+++ b/client/src/component.gleam
@@ -1,6 +1,7 @@
 import formal/form.{type Form}
 import gleam/dynamic/decode
 import gleam/int
+import gleam/json
 import gleam/list
 import gleam/option.{type Option, None, Some}
 import lustre/attribute
@@ -97,6 +98,24 @@ pub fn scout_loader(text: String) -> Element(msg) {
       attribute.attribute("size", "base"),
     ],
     [],
+  )
+}
+
+pub fn scout_drawer(
+  open: Bool,
+  heading: String,
+  on_exit: msg,
+  content: List(Element(msg)),
+) -> Element(msg) {
+  element.element(
+    "scout-drawer",
+    [
+      attribute.property("open", json.bool(open)),
+      attribute.attribute("heading", heading),
+      attribute.attribute("show-exit-button", "true"),
+      event.on("exitButtonClicked", decode.success(on_exit)),
+    ],
+    content,
   )
 }
 

--- a/client/test/client_test.gleam
+++ b/client/test/client_test.gleam
@@ -33,11 +33,7 @@ fn id_c() -> Uuid {
   uid("00000000-0000-0000-0000-00000000000c")
 }
 
-fn a_summary(
-  id: Uuid,
-  title: String,
-  max: Option(Int),
-) -> model.ActivitySummary {
+fn a_summary(id: Uuid, title: String, max: Option(Int)) -> model.ActivitySummary {
   model.ActivitySummary(
     id:,
     title:,

--- a/server/src/server/model/location.gleam
+++ b/server/src/server/model/location.gleam
@@ -142,9 +142,7 @@ pub fn fetch_all_dict(
   })
 }
 
-pub fn from_list_location_tags_row(
-  row: sql.ListLocationTagsRow,
-) -> LocationTag {
+pub fn from_list_location_tags_row(row: sql.ListLocationTagsRow) -> LocationTag {
   LocationTag(
     id: row.id,
     name: model.BilingualString(sv: row.name, en: row.name_en),

--- a/server/src/server/web.gleam
+++ b/server/src/server/web.gleam
@@ -21,7 +21,7 @@ import ywt/verify_key.{type VerifyKey}
 
 pub const base_path = "/_services/booking"
 
-const scouterna_ui_webc_version = "4.3.4"
+pub const scouterna_ui_webc_version = "4.4.2"
 
 /// Roles defined on the `j26-booking` Keycloak client, carried in the
 /// `resource_access.j26-booking.roles` claim of the access token.

--- a/server/src/server/web.gleam
+++ b/server/src/server/web.gleam
@@ -21,7 +21,7 @@ import ywt/verify_key.{type VerifyKey}
 
 pub const base_path = "/_services/booking"
 
-pub const scouterna_ui_webc_version = "4.4.2"
+pub const scouterna_ui_webc_version = "4.4.4"
 
 /// Roles defined on the `j26-booking` Keycloak client, carried in the
 /// `resource_access.j26-booking.roles` claim of the access token.

--- a/server/src/server/web.gleam
+++ b/server/src/server/web.gleam
@@ -266,11 +266,7 @@ pub fn with_authenticated_user(
 
 /// Calls `next` when the user holds `role`, otherwise short-circuits with a
 /// 403 response. `Admin` implies every role.
-pub fn require_role(
-  user: User,
-  role: Role,
-  next: fn() -> Response,
-) -> Response {
+pub fn require_role(user: User, role: Role, next: fn() -> Response) -> Response {
   case list.contains(user.roles, role) || list.contains(user.roles, Admin) {
     True -> next()
     False -> wisp.response(403)

--- a/server/src/server/web/favourite.gleam
+++ b/server/src/server/web/favourite.gleam
@@ -8,11 +8,7 @@ import server/web
 import wisp.{type Request, type Response}
 import youid/uuid
 
-pub fn put(
-  req: Request,
-  activity_id_str: String,
-  ctx: web.Context,
-) -> Response {
+pub fn put(req: Request, activity_id_str: String, ctx: web.Context) -> Response {
   use <- wisp.require_method(req, Put)
   web.discard_body(req)
   use user <- web.with_authenticated_user(ctx)


### PR DESCRIPTION
# UI lift

Bumps `@scouterna/ui-webc` and applies a round of visual/UX polish to the activities list and booking flow.

## Changes

- **Booking form moved into a drawer** — the booking form on the activity detail page now renders inside a `scout-drawer` (new `component.scout_drawer` helper) instead of inline in a card. The drawer heading reflects whether the user is creating a new booking or editing an existing one.
- **Detail page actions stay visible** — "Ändra bokning" / "Avboka" no longer disappear while the booking drawer is open; previously they were hidden behind the inline form.
- **Activities list styling cleanup** — top bar and "more filters" panel switched from cards to a flatter bordered-bottom style; spacing/padding adjusted (`view_activities_list`, `view_more_filters_panel`, `view_grouped_activities`).
- **Filter chip styling** — selected chips now use the brand background color instead of blue, and gained `aria-pressed` for accessibility. Removed a stray `size="small"` on `filter_pill_icon`.
- **`@scouterna/ui-webc` bumped 4.3.4 → 4.4.4** (client `gleam.toml`, `server/src/server/web.gleam`), plus `@scouterna/tailwind-theme` 0.0.5 → 0.0.6.
- **Fixed `bump-ui-webc.sh`** — the version-bump sed for `web.gleam` previously renamed the constant to `ui_webc_version` and dropped `pub`; now it only substitutes the version string in place.