### PR TITLE
feat: add ledare and funktionär target groups

### DIFF
--- a/client/src/client.gleam
+++ b/client/src/client.gleam
@@ -7346,6 +7346,8 @@ fn target_group_label(target_group: TargetGroup) -> String {
     model.Aventyrare -> "Äventyrare"
     model.Utmanare -> "Utmanare"
     model.Rover -> "Rover"
+    model.Ledare -> "Ledare"
+    model.Funktionar -> "Funktionär"
   }
 }
 

--- a/server/priv/migrations/20260722125516-add_ledare_funktionar_target_groups.sql
+++ b/server/priv/migrations/20260722125516-add_ledare_funktionar_target_groups.sql
@@ -1,0 +1,22 @@
+--- migration:up
+ALTER TYPE target_group ADD VALUE 'ledare';
+ALTER TYPE target_group ADD VALUE 'funktionar';
+--- migration:down
+DELETE FROM activity_target_group WHERE target_group IN ('ledare', 'funktionar');
+
+CREATE TYPE target_group_old AS ENUM (
+    'sparare',
+    'upptackare',
+    'aventyrare',
+    'utmanare',
+    'rover'
+);
+
+ALTER TABLE activity_target_group
+    ALTER COLUMN target_group TYPE target_group_old
+    USING target_group::text::target_group_old;
+
+DROP TYPE target_group;
+
+ALTER TYPE target_group_old RENAME TO target_group;
+--- migration:end

--- a/server/priv/openapi.yaml
+++ b/server/priv/openapi.yaml
@@ -2139,13 +2139,15 @@ components:
 
     TargetGroup:
       type: string
-      description: A scout age section an activity can target ("målgrupp"). A fixed, closed set.
+      description: A scout age section or adult role an activity can target ("målgrupp"). A fixed, closed set.
       enum:
         - sparare
         - upptackare
         - aventyrare
         - utmanare
         - rover
+        - ledare
+        - funktionar
       example: "sparare"
 
     ActivityTag:

--- a/server/src/server/model/activity.gleam
+++ b/server/src/server/model/activity.gleam
@@ -73,6 +73,8 @@ pub fn sql_target_group_to_model(target_group: sql.TargetGroup) -> TargetGroup {
     sql.Aventyrare -> model.Aventyrare
     sql.Utmanare -> model.Utmanare
     sql.Rover -> model.Rover
+    sql.Ledare -> model.Ledare
+    sql.Funktionar -> model.Funktionar
   }
 }
 
@@ -85,6 +87,8 @@ pub fn model_target_group_to_sql(target_group: TargetGroup) -> sql.TargetGroup {
     model.Aventyrare -> sql.Aventyrare
     model.Utmanare -> sql.Utmanare
     model.Rover -> sql.Rover
+    model.Ledare -> sql.Ledare
+    model.Funktionar -> sql.Funktionar
   }
 }
 

--- a/server/src/server/sql.gleam
+++ b/server/src/server/sql.gleam
@@ -4329,6 +4329,8 @@ RETURNING id
 /// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
 ///
 pub type TargetGroup {
+  Funktionar
+  Ledare
   Rover
   Utmanare
   Aventyrare
@@ -4339,17 +4341,21 @@ pub type TargetGroup {
 fn target_group_decoder() -> decode.Decoder(TargetGroup) {
   use target_group <- decode.then(decode.string)
   case target_group {
+    "funktionar" -> decode.success(Funktionar)
+    "ledare" -> decode.success(Ledare)
     "rover" -> decode.success(Rover)
     "utmanare" -> decode.success(Utmanare)
     "aventyrare" -> decode.success(Aventyrare)
     "upptackare" -> decode.success(Upptackare)
     "sparare" -> decode.success(Sparare)
-    _ -> decode.failure(Rover, "TargetGroup")
+    _ -> decode.failure(Funktionar, "TargetGroup")
   }
 }
 
 fn target_group_encoder(target_group) -> pog.Value {
   case target_group {
+    Funktionar -> "funktionar"
+    Ledare -> "ledare"
     Rover -> "rover"
     Utmanare -> "utmanare"
     Aventyrare -> "aventyrare"

--- a/shared/src/shared/model.gleam
+++ b/shared/src/shared/model.gleam
@@ -158,22 +158,25 @@ pub fn bilingual_string_to_json(value: BilingualString) -> Json {
   json.object([#("sv", json.string(value.sv)), #("en", json.string(value.en))])
 }
 
-/// The scout age sections an activity can target ("målgrupp"). A fixed, closed
-/// set — the server persists it as a Postgres enum and Squirrel generates its
-/// own matching type; this shared type is the identity used across the API and
-/// client. Bilingual display labels live in the client's translations.
+/// The scout age sections plus adult roles an activity can target
+/// ("målgrupp"). A fixed, closed set — the server persists it as a Postgres
+/// enum and Squirrel generates its own matching type; this shared type is the
+/// identity used across the API and client. Bilingual display labels live in
+/// the client's translations.
 pub type TargetGroup {
   Sparare
   Upptackare
   Aventyrare
   Utmanare
   Rover
+  Ledare
+  Funktionar
 }
 
-/// Every target group in age order — drives client filter chips and gives a
-/// stable display order the database cannot guarantee.
+/// Every target group in age order (adult roles last) — drives client filter
+/// chips and gives a stable display order the database cannot guarantee.
 pub fn target_groups_all() -> List(TargetGroup) {
-  [Sparare, Upptackare, Aventyrare, Utmanare, Rover]
+  [Sparare, Upptackare, Aventyrare, Utmanare, Rover, Ledare, Funktionar]
 }
 
 /// The wire/DB string for a target group (matches the Postgres enum values).
@@ -184,6 +187,8 @@ pub fn target_group_to_string(target_group: TargetGroup) -> String {
     Aventyrare -> "aventyrare"
     Utmanare -> "utmanare"
     Rover -> "rover"
+    Ledare -> "ledare"
+    Funktionar -> "funktionar"
   }
 }
 
@@ -195,6 +200,8 @@ pub fn target_group_from_string(raw: String) -> Result(TargetGroup, Nil) {
     "aventyrare" -> Ok(Aventyrare)
     "utmanare" -> Ok(Utmanare)
     "rover" -> Ok(Rover)
+    "ledare" -> Ok(Ledare)
+    "funktionar" -> Ok(Funktionar)
     _ -> Error(Nil)
   }
 }


### PR DESCRIPTION
## Summary
- Extends the `target_group` Postgres enum with `ledare` and `funktionar` so activities aimed at leaders and volunteers can be tagged and filtered
- DB/wire strings stay ASCII per the existing convention; the diacritic only appears in the client display label ("Funktionär")
- Migration down path is fully reversible: rows using the new values are deleted, then the enum is recreated with the original five values (same pattern as `drop_user_role`)
- Touches the full stack in lockstep: migration → regenerated `sql.gleam` (Squirrel) → shared `TargetGroup` model → server sql↔model conversions → client labels → OpenAPI spec

## Verification
- Migration applies cleanly and the down/up round-trip works
- `gleam test` in `server/`: 70 passed
- Drove the running app: PUT/GET on `/api/activities/:id` round-trips `["ledare", "funktionar"]`; invalid values (`funktionär`, `chef`) are rejected with 400
- All seven chips render in the browse filters and the admin edit drawer (Spårare → Funktionär); toggling Ledare in the edit form persists and the badge renders on the detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DUcG2Zk8vR7rAcodqU5p3b