### PR TITLE
feat(auth): guard location editing with its own locations:manage role

### DIFF
--- a/.env.sh.template
+++ b/.env.sh.template
@@ -3,3 +3,5 @@ export DATABASE_URL="postgres://postgres:postgres@localhost:5433/j26booking"
 export DB_POOL_SIZE="15"
 export PORT="8000"
 export SECRET_KEY_BASE="development-secret-key-change-this-in-production-must-be-at-least-64-characters-long"
+# Optional: when booking opens globally (RFC 3339). Defaults to the start of the camp.
+# export BOOKING_OPENS_AT="2026-07-25T00:00:00+02:00"

--- a/server/README.md
+++ b/server/README.md
@@ -68,6 +68,7 @@ The application will be available at http://localhost:8000
 | `DB_POOL_SIZE` | 15 | Connection pool size |
 | `SECRET_KEY_BASE` | (random) | Secret key for sessions (required in production) |
 | `OPEN_ID_CONFIGURATION_URL` | https://app.dev.j26.se/auth/... | OpenID Connect discovery URL |
+| `BOOKING_OPENS_AT` | 2026-07-25T00:00:00+02:00 | Global date booking opens (RFC 3339), defaulting to the start of the camp. An invalid value fails startup. Activities can override this per row. |
 | `DEV_AUTH_ROLES` | (unset) | **Local dev only.** Comma-separated roles (e.g. `admin` or `bookings:self:create,bookings:read`). When set, requests without an access token authenticate as the seeded dev user with these roles. Never set in production. |
 
 **Note:** The base path `/_services/booking` is hardcoded as `web.base_path` (not an environment variable). All routes are served under this prefix.

--- a/server/priv/openapi.yaml
+++ b/server/priv/openapi.yaml
@@ -1560,7 +1560,9 @@ paths:
       description: |
         Create a location. `opening_hours` (default `{}`) is stored verbatim
         and `tags` (default `[]`) are the ids of tags to link to it. Returns the
-        created location; the `Location` response header points at it.
+        created location; the `Location` response header points at it. Requires
+        authentication (`401` otherwise) and the `locations:manage` role
+        (`403` otherwise).
       operationId: createLocation
       security:
         - bearerAuth: []
@@ -1619,7 +1621,10 @@ paths:
       tags:
         - Locations
       summary: Update a location
-      description: Replace all fields of a location, including its tag links.
+      description: >-
+        Replace all fields of a location, including its tag links. Requires
+        authentication (`401` otherwise) and the `locations:manage` role
+        (`403` otherwise).
       operationId: updateLocation
       security:
         - bearerAuth: []
@@ -1654,7 +1659,10 @@ paths:
       tags:
         - Locations
       summary: Delete a location
-      description: Deletes the location together with its tag links.
+      description: >-
+        Deletes the location together with its tag links. Requires
+        authentication (`401` otherwise) and the `locations:manage` role
+        (`403` otherwise).
       operationId: deleteLocation
       security:
         - bearerAuth: []
@@ -1856,7 +1864,10 @@ paths:
       tags:
         - Locations
       summary: Create a location tag
-      description: Create a new location tag with a bilingual name and icon.
+      description: >-
+        Create a new location tag with a bilingual name and icon. Requires
+        authentication (`401` otherwise) and the `locations:manage` role
+        (`403` otherwise).
       operationId: createLocationTag
       security:
         - bearerAuth: []
@@ -1915,7 +1926,10 @@ paths:
       tags:
         - Locations
       summary: Update a location tag
-      description: Update an existing location tag's bilingual name and icon.
+      description: >-
+        Update an existing location tag's bilingual name and icon. Requires
+        authentication (`401` otherwise) and the `locations:manage` role
+        (`403` otherwise).
       operationId: updateLocationTag
       security:
         - bearerAuth: []
@@ -1950,7 +1964,10 @@ paths:
       tags:
         - Locations
       summary: Delete a location tag
-      description: Deletes the tag and unlinks it from any locations.
+      description: >-
+        Deletes the tag and unlinks it from any locations. Requires
+        authentication (`401` otherwise) and the `locations:manage` role
+        (`403` otherwise).
       operationId: deleteLocationTag
       security:
         - bearerAuth: []

--- a/server/src/server/web.gleam
+++ b/server/src/server/web.gleam
@@ -36,6 +36,7 @@ pub type Role {
   BookingsOthersCreate
   BookingsRead
   BookingsSelfCreate
+  LocationsManage
   Admin
 }
 
@@ -45,6 +46,7 @@ pub fn string_to_role(value: String) -> Result(Role, Nil) {
     "bookings:others:create" -> Ok(BookingsOthersCreate)
     "bookings:read" -> Ok(BookingsRead)
     "bookings:self:create" -> Ok(BookingsSelfCreate)
+    "locations:manage" -> Ok(LocationsManage)
     "admin" -> Ok(Admin)
     _ -> Error(Nil)
   }
@@ -56,6 +58,7 @@ pub fn role_to_string(role: Role) -> String {
     BookingsOthersCreate -> "bookings:others:create"
     BookingsRead -> "bookings:read"
     BookingsSelfCreate -> "bookings:self:create"
+    LocationsManage -> "locations:manage"
     Admin -> "admin"
   }
 }

--- a/server/src/server/web/location.gleam
+++ b/server/src/server/web/location.gleam
@@ -127,7 +127,7 @@ pub fn get_one(req: Request, id: String, ctx: web.Context) -> Response {
 pub fn create(req: Request, ctx: web.Context) -> Response {
   use <- wisp.require_method(req, Post)
   use user <- web.with_authenticated_user(ctx)
-  use <- web.require_role(user, web.ActivitiesManage)
+  use <- web.require_role(user, web.LocationsManage)
   use body <- wisp.require_json(req)
   use input <- given.ok(decode.run(body, location_input_decoder()), fn(_) {
     wisp.bad_request("Invalid JSON payload")
@@ -207,7 +207,7 @@ type UpdateError {
 pub fn update(req: Request, id: String, ctx: web.Context) -> Response {
   use <- wisp.require_method(req, Put)
   use user <- web.with_authenticated_user(ctx)
-  use <- web.require_role(user, web.ActivitiesManage)
+  use <- web.require_role(user, web.LocationsManage)
   use location_id <- given.ok(uuid.from_string(id), fn(_) {
     wisp.bad_request("Invalid location ID format")
   })
@@ -301,7 +301,7 @@ pub fn delete(req: Request, id: String, ctx: web.Context) -> Response {
   use <- wisp.require_method(req, Delete)
   web.discard_body(req)
   use user <- web.with_authenticated_user(ctx)
-  use <- web.require_role(user, web.ActivitiesManage)
+  use <- web.require_role(user, web.LocationsManage)
   use location_id <- given.ok(uuid.from_string(id), fn(_) {
     wisp.bad_request("Invalid location ID format")
   })
@@ -355,7 +355,7 @@ pub fn get_tag(req: Request, id: String, ctx: web.Context) -> Response {
 pub fn create_tag(req: Request, ctx: web.Context) -> Response {
   use <- wisp.require_method(req, Post)
   use user <- web.with_authenticated_user(ctx)
-  use <- web.require_role(user, web.ActivitiesManage)
+  use <- web.require_role(user, web.LocationsManage)
   use body <- wisp.require_json(req)
   use input <- given.ok(decode.run(body, location_tag_input_decoder()), fn(_) {
     wisp.bad_request("Invalid JSON payload")
@@ -390,7 +390,7 @@ pub fn create_tag(req: Request, ctx: web.Context) -> Response {
 pub fn update_tag(req: Request, id: String, ctx: web.Context) -> Response {
   use <- wisp.require_method(req, Put)
   use user <- web.with_authenticated_user(ctx)
-  use <- web.require_role(user, web.ActivitiesManage)
+  use <- web.require_role(user, web.LocationsManage)
   use tag_id <- given.ok(uuid.from_string(id), fn(_) {
     wisp.bad_request("Invalid location tag ID format")
   })
@@ -422,7 +422,7 @@ pub fn delete_tag(req: Request, id: String, ctx: web.Context) -> Response {
   use <- wisp.require_method(req, Delete)
   web.discard_body(req)
   use user <- web.with_authenticated_user(ctx)
-  use <- web.require_role(user, web.ActivitiesManage)
+  use <- web.require_role(user, web.LocationsManage)
   use tag_id <- given.ok(uuid.from_string(id), fn(_) {
     wisp.bad_request("Invalid location tag ID format")
   })

--- a/server/test/server/web_test.gleam
+++ b/server/test/server/web_test.gleam
@@ -301,6 +301,7 @@ pub fn string_to_role_test() {
   assert web.string_to_role("bookings:read") == Ok(web.BookingsRead)
   assert web.string_to_role("bookings:self:create")
     == Ok(web.BookingsSelfCreate)
+  assert web.string_to_role("locations:manage") == Ok(web.LocationsManage)
   assert web.string_to_role("admin") == Ok(web.Admin)
   assert web.string_to_role("default-roles-jamboree26") == Error(Nil)
 }


### PR DESCRIPTION
## Summary

Location and location-tag mutations previously reused the `activities:manage` role. This adds a dedicated `locations:manage` role and requires it on create/update/delete for `/api/locations` and `/api/location-tags`.

- New `LocationsManage` variant in `web.Role`, mapped to `locations:manage` — flows through `/api/me` and `DEV_AUTH_ROLES` automatically
- All six location/location-tag mutation handlers now guard with `web.LocationsManage`; GET endpoints stay public and `admin` still implies every role
- OpenAPI spec now states the auth + role requirement on these endpoints (it previously named no role for them)
- `string_to_role` round-trip test extended with the new role

## Decisions

- Location tags are covered by `locations:manage` too — they are only used by locations and edited in the same flow
- `activities:manage` no longer grants location editing; a user needing both must hold both roles

## Rollout note

The `locations:manage` client role must be created on the `j26-booking` Keycloak client and assigned to the relevant users before this reaches an environment where anyone edits locations.

## Test plan

- [x] `gleam test` — 70 passed
- [ ] With `DEV_AUTH_ROLES=activities:manage`, `PUT /api/locations/:id` returns 403
- [ ] With `DEV_AUTH_ROLES=locations:manage`, location and location-tag create/update/delete succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaPAAw7xweajLoGs8eaYf8