### PR TITLE
feat(client): filter the activity list by location

### DIFF
--- a/client/src/client.gleam
+++ b/client/src/client.gleam
@@ -193,6 +193,8 @@ fn english_translations() -> g18n.Translations {
   |> g18n.add_translation("list.filter.more", "More filters")
   |> g18n.add_translation("list.filter.audience_label", "Target audience")
   |> g18n.add_translation("list.filter.tags_label", "Tags")
+  |> g18n.add_translation("list.filter.location_label", "Location")
+  |> g18n.add_translation("list.filter.location_search", "Search location")
   |> g18n.add_translation("list.bucket.forenoon", "Morning")
   |> g18n.add_translation("list.bucket.afternoon", "Afternoon")
   |> g18n.add_translation("list.bucket.evening", "Evening")
@@ -392,6 +394,8 @@ fn swedish_translations() -> g18n.Translations {
   |> g18n.add_translation("list.filter.more", "Fler filter")
   |> g18n.add_translation("list.filter.audience_label", "Målgrupp")
   |> g18n.add_translation("list.filter.tags_label", "Taggar")
+  |> g18n.add_translation("list.filter.location_label", "Plats")
+  |> g18n.add_translation("list.filter.location_search", "Sök plats")
   |> g18n.add_translation("list.bucket.forenoon", "Förmiddag")
   |> g18n.add_translation("list.bucket.afternoon", "Eftermiddag")
   |> g18n.add_translation("list.bucket.evening", "Kväll")
@@ -885,6 +889,25 @@ pub fn default_edit_ui() -> EditUi {
   )
 }
 
+/// Transient view state for the list filter panel's location multi-select
+/// combobox. The chosen location *ids* live in `ListFilters.locations` (they are
+/// real filter state); only the search query and open/closed state — which are
+/// pure UI — live here, mirroring how `EditUi` holds the edit form picker's
+/// `location_query` / `location_open`.
+pub type LocationFilterUi {
+  LocationFilterUi(
+    /// Free-text filter typed into the combobox (case-insensitive match on the
+    /// localized name). Shown in the field while the dropdown is open.
+    query: String,
+    /// Whether the combobox's dropdown list is open.
+    open: Bool,
+  )
+}
+
+pub fn default_location_filter_ui() -> LocationFilterUi {
+  LocationFilterUi(query: "", open: False)
+}
+
 pub type ActivitiesFilterTab {
   TabActivities
   TabBeachBus
@@ -899,6 +922,7 @@ pub type ListFilters {
     more_open: Bool,
     target_groups: List(TargetGroup),
     tags: List(Uuid),
+    locations: List(Uuid),
   )
 }
 
@@ -909,6 +933,7 @@ pub fn default_filters() -> ListFilters {
     more_open: False,
     target_groups: [],
     tags: [],
+    locations: [],
   )
 }
 
@@ -1133,6 +1158,10 @@ pub type Model {
     // reveal). Kept here rather than in the multi-variant `EditState` so it can
     // be updated with a plain record update; reset whenever the form opens.
     edit_ui: EditUi,
+    // Transient view state (search query + open/closed) for the list filter
+    // panel's location combobox. The selected location ids live in
+    // `ListFilters.locations`; only this pure UI state lives on the Model.
+    location_filter_ui: LocationFilterUi,
     // Transient view state for the booking form's book-for-other section
     // (target + kår combobox), the `edit_ui` of the booking drawer. Reset
     // whenever the booking form opens.
@@ -1675,6 +1704,7 @@ fn to_summary(a: Activity) -> ActivitySummary {
     start_time: a.start_time,
     end_time: a.end_time,
     location_name: option.map(a.location, fn(l) { l.name }),
+    location_id: option.map(a.location, fn(l) { l.id }),
     tags: a.tags,
     target_groups: a.target_groups,
     cancellation: a.cancellation,
@@ -2115,6 +2145,7 @@ fn init(_flags) -> #(Model, Effect(Msg)) {
       // fields fill in then.
       booker: IdentityUnknown,
       edit_ui: default_edit_ui(),
+      location_filter_ui: default_location_filter_ui(),
       booking_ui: default_booking_ui(),
       // Fetched once /api/me shows the user may book for others.
       scout_groups: NotAsked,
@@ -2220,6 +2251,11 @@ pub type Msg {
   UserSearchedLocation(String)
   UserOpenedLocationDropdown
   UserClosedLocationDropdown
+  // Location filter (list "More filters" panel — multi-select combobox)
+  UserToggledLocationFilter(Uuid)
+  UserSearchedLocationFilter(String)
+  UserOpenedLocationFilterDropdown
+  UserClosedLocationFilterDropdown
   // Book-for-other (booking form): target toggle + kår combobox
   UserSelectedBookingTarget(Int)
   UserSelectedBookingGroup(Int)
@@ -3057,6 +3093,47 @@ pub fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
     // before this blur, so a selection is never lost to the close.
     UserClosedLocationDropdown -> #(
       Model(..model, edit_ui: EditUi(..model.edit_ui, location_open: False)),
+      effect.none(),
+    )
+
+    // Location filter (list panel): multi-select, so a pick toggles membership
+    // of the id set in `ListFilters.locations` and the dropdown stays open so
+    // more can be picked. Mirrors `UserToggledTag`, but there is no activity-form
+    // branch — the form's location picker is the separate single-select above.
+    UserToggledLocationFilter(location_id) ->
+      update_filters(model, fn(f) {
+        ListFilters(..f, locations: toggle_member(f.locations, location_id))
+      })
+
+    // Typing filters the list and keeps it open.
+    UserSearchedLocationFilter(query) -> #(
+      Model(..model, location_filter_ui: LocationFilterUi(query:, open: True)),
+      effect.none(),
+    )
+
+    // Clicking the field opens the list on a clean filter, so the full list of
+    // locations shows; a click while already open must not wipe the query.
+    UserOpenedLocationFilterDropdown -> {
+      let query = case model.location_filter_ui.open {
+        True -> model.location_filter_ui.query
+        False -> ""
+      }
+      #(
+        Model(..model, location_filter_ui: LocationFilterUi(query:, open: True)),
+        effect.none(),
+      )
+    }
+
+    // Blurring the field closes the list. Option toggles fire on `mousedown`,
+    // before this blur, so a selection is never lost to the close.
+    UserClosedLocationFilterDropdown -> #(
+      Model(
+        ..model,
+        location_filter_ui: LocationFilterUi(
+          ..model.location_filter_ui,
+          open: False,
+        ),
+      ),
       effect.none(),
     )
 
@@ -4438,6 +4515,7 @@ fn view(model: Model) -> Element(Msg) {
         model.list_warning_dismissed,
         model.edit_ui,
         model.locations,
+        model.location_filter_ui,
         model.session,
       )
     ActivityDetailPage(id, booking) ->
@@ -4491,6 +4569,7 @@ fn view_activities_list(
   warning_dismissed: Bool,
   edit_ui: EditUi,
   locations: Dict(Uuid, Location),
+  location_filter_ui: LocationFilterUi,
   session: Session,
 ) -> Element(Msg) {
   let t = fn(key) { g18n.translate(translator, key) }
@@ -4528,7 +4607,14 @@ fn view_activities_list(
     // `more_open` survives tab switches so the panel reappears when returning
     // to a tab that has filter controls; the recurring tabs never show it.
     case filters.more_open && tab_has_search_and_filters(filters.tab) {
-      True -> view_more_filters_panel(translator, filters, activity_tags)
+      True ->
+        view_more_filters_panel(
+          translator,
+          filters,
+          activity_tags,
+          locations,
+          location_filter_ui,
+        )
       False -> element.none()
     },
     html.div([attribute.class("flex flex-col gap-3 mt-3")], [
@@ -4820,6 +4906,8 @@ fn view_more_filters_panel(
   translator: Translator,
   filters: ListFilters,
   activity_tags: Dict(Uuid, ActivityTag),
+  locations: Dict(Uuid, Location),
+  location_filter_ui: LocationFilterUi,
 ) -> Element(Msg) {
   html.div(
     [
@@ -4827,11 +4915,21 @@ fn view_more_filters_panel(
         "bg-white border-b border-gray-200 p-3 flex flex-col gap-3",
       ),
     ],
-    view_target_group_and_tag_pickers(
-      translator,
-      filters.target_groups,
-      filters.tags,
-      activity_tags,
+    list.append(
+      view_target_group_and_tag_pickers(
+        translator,
+        filters.target_groups,
+        filters.tags,
+        activity_tags,
+      ),
+      [
+        view_location_filter(
+          translator,
+          locations,
+          filters.locations,
+          location_filter_ui,
+        ),
+      ],
     ),
   )
 }
@@ -4993,6 +5091,127 @@ fn view_location_picker(
                 )
               })
             ],
+          )
+      },
+    ]),
+  ])
+}
+
+/// The list filter panel's location filter: a searchable multi-select combobox.
+/// Typing filters the (many) locations by localized name; clicking an option
+/// toggles its membership of the selected set (`ListFilters.locations`) and the
+/// list stays open so several can be picked. Chosen locations show as removable
+/// chips above the field (clicking a chip toggles it off). Unlike the form's
+/// single-select `view_location_picker`, there is no "no location" entry.
+///
+/// Options toggle on `mousedown` — which fires before the field's blur — so the
+/// blur that closes the list never swallows the click.
+fn view_location_filter(
+  translator: Translator,
+  locations: Dict(Uuid, Location),
+  selected: List(Uuid),
+  ui: LocationFilterUi,
+) -> Element(Msg) {
+  let t = fn(key) { g18n.translate(translator, key) }
+  let name_of = fn(id) {
+    case dict.get(locations, id) {
+      Ok(l) -> localized(translator, l.name)
+      Error(_) -> ""
+    }
+  }
+  let matches =
+    dict.values(locations)
+    |> list.sort(fn(a, b) {
+      string.compare(
+        localized(translator, a.name),
+        localized(translator, b.name),
+      )
+    })
+    |> list.filter(fn(l) {
+      case ui.query |> string.trim |> string.lowercase {
+        "" -> True
+        needle ->
+          string.contains(
+            string.lowercase(localized(translator, l.name)),
+            needle,
+          )
+      }
+    })
+  let option_button = fn(label: String, is_selected: Bool, msg: Msg) {
+    let base =
+      "w-full text-left px-3 py-2 text-body-sm cursor-pointer hover:bg-gray-100 "
+    html.button(
+      [
+        attribute.type_("button"),
+        attribute.class(case is_selected {
+          True -> base <> "bg-gray-100 font-semibold"
+          False -> base
+        }),
+        // mousedown (not click) so the toggle lands before the field's blur.
+        event.on("mousedown", decode.success(msg)),
+      ],
+      [element.text(label)],
+    )
+  }
+  html.div([attribute.class("flex flex-col gap-2")], [
+    html.h4([attribute.class("text-body-sm font-semibold")], [
+      element.text(t("list.filter.location_label")),
+    ]),
+    // The chosen locations, each removed by clicking (toggles it off).
+    case selected {
+      [] -> element.none()
+      _ ->
+        html.div(
+          [attribute.class("flex flex-wrap gap-2")],
+          list.map(selected, fn(id) {
+            component.filter_chip(
+              name_of(id),
+              True,
+              UserToggledLocationFilter(id),
+            )
+          }),
+        )
+    },
+    html.div([attribute.class("relative")], [
+      // Clicking the field opens the list; typing filters it; blur closes it.
+      html.div(
+        [event.on("click", decode.success(UserOpenedLocationFilterDropdown))],
+        [
+          element.element(
+            "scout-input",
+            [
+              attribute.attribute("type", "text"),
+              attribute.attribute(
+                "placeholder",
+                t("list.filter.location_search"),
+              ),
+              attribute.attribute("value", ui.query),
+              event.on_input(UserSearchedLocationFilter),
+              event.on(
+                "scoutBlur",
+                decode.success(UserClosedLocationFilterDropdown),
+              ),
+            ],
+            [],
+          ),
+        ],
+      ),
+      case ui.open {
+        False -> element.none()
+        True ->
+          html.div(
+            [
+              attribute.class(
+                "absolute left-0 right-0 z-10 mt-1 max-h-56 overflow-y-auto rounded-md border border-gray-300 bg-white shadow-lg",
+              ),
+            ],
+            list.map(matches, fn(l) {
+              option_button(
+                localized(translator, l.name),
+                list.contains(selected, l.id),
+                UserToggledLocationFilter(l.id),
+              )
+            }),
           )
       },
     ]),
@@ -7443,7 +7662,8 @@ pub fn apply_filters(
   // filter state left over from the other tabs must not narrow their lists.
   let f = case tab_has_search_and_filters(f.tab) {
     True -> f
-    False -> ListFilters(..f, search: "", target_groups: [], tags: [])
+    False ->
+      ListFilters(..f, search: "", target_groups: [], tags: [], locations: [])
   }
   let needle = string.lowercase(string.trim(f.search))
   use item <- list.filter(items)
@@ -7463,7 +7683,8 @@ pub fn apply_filters(
   }
   // Membership (tab/favourites) is resolved upstream via the source id windows
   // and the statuses-derived favourites set, so every tab is pass-through on
-  // status here; only search + day + target group + tags filter client-side.
+  // status here; only search + day + target group + tags + location filter
+  // client-side.
   let target_group_match = case f.target_groups {
     [] -> True
     selected -> lists_intersect(summary.target_groups, selected)
@@ -7472,7 +7693,17 @@ pub fn apply_filters(
     [] -> True
     selected -> lists_intersect(summary.tags, selected)
   }
-  title_match && day_match && target_group_match && tag_match
+  // A summary has at most one location, so match is membership of its id in the
+  // selected set. Activities with no location are excluded when a location
+  // filter is active (same intuition as the tag filter).
+  let location_match = case f.locations {
+    [] -> True
+    selected ->
+      summary.location_id
+      |> option.map(list.contains(selected, _))
+      |> option.unwrap(False)
+  }
+  title_match && day_match && target_group_match && tag_match && location_match
 }
 
 fn date_to_iso(date: calendar.Date) -> String {

--- a/client/test/client_test.gleam
+++ b/client/test/client_test.gleam
@@ -49,6 +49,7 @@ fn a_summary(
     start_time: timestamp.from_unix_seconds(1_750_000_000),
     end_time: timestamp.from_unix_seconds(1_750_003_600),
     location_name: None,
+    location_id: None,
     tags: [],
     target_groups: [],
     cancellation: None,
@@ -170,6 +171,7 @@ fn base_model() -> client.Model {
     session: client.SessionUnknown,
     booker: client.IdentityUnknown,
     edit_ui: client.default_edit_ui(),
+    location_filter_ui: client.default_location_filter_ui(),
     booking_ui: client.default_booking_ui(),
     scout_groups: client.NotAsked,
   )
@@ -472,6 +474,64 @@ pub fn apply_filters_ignores_search_on_recurring_tabs_test() {
       tab: client.TabBeachBus,
     )
   assert client.apply_filters([climb, swim], filters, None) == [climb, swim]
+}
+
+fn loc_x() -> Uuid {
+  uid("00000000-0000-0000-0000-0000000000f1")
+}
+
+fn loc_y() -> Uuid {
+  uid("00000000-0000-0000-0000-0000000000f2")
+}
+
+// A summary at a given location (the base helper has no location).
+fn summary_at(
+  id: Uuid,
+  title: String,
+  location: Uuid,
+) -> model.ActivitySummary {
+  model.ActivitySummary(
+    ..a_summary(id, title, None),
+    location_id: Some(location),
+  )
+}
+
+pub fn apply_filters_location_keeps_only_selected_test() {
+  let at_x =
+    client.CardItem(summary_at(id_a(), "A", loc_x()), model.NotInterested, None)
+  let at_y =
+    client.CardItem(summary_at(id_b(), "B", loc_y()), model.NotInterested, None)
+  let filters =
+    client.ListFilters(..client.default_filters(), locations: [loc_x()])
+  assert client.apply_filters([at_x, at_y], filters, None) == [at_x]
+}
+
+// With a location filter active, an activity with no location is excluded (same
+// intuition as the tag/target-group filters).
+pub fn apply_filters_location_excludes_activities_without_location_test() {
+  let at_x =
+    client.CardItem(summary_at(id_a(), "A", loc_x()), model.NotInterested, None)
+  let no_location =
+    client.CardItem(a_summary(id_b(), "B", None), model.NotInterested, None)
+  let filters =
+    client.ListFilters(..client.default_filters(), locations: [loc_x()])
+  assert client.apply_filters([at_x, no_location], filters, None) == [at_x]
+}
+
+// The location filter has no controls on the recurring tabs, so leftover
+// selections from another tab must not narrow their lists.
+pub fn apply_filters_ignores_location_on_recurring_tabs_test() {
+  let at_x =
+    client.CardItem(summary_at(id_a(), "A", loc_x()), model.NotInterested, None)
+  let at_y =
+    client.CardItem(summary_at(id_b(), "B", loc_y()), model.NotInterested, None)
+  let filters =
+    client.ListFilters(
+      ..client.default_filters(),
+      locations: [loc_x()],
+      tab: client.TabClimbingWall,
+    )
+  assert client.apply_filters([at_x, at_y], filters, None) == [at_x, at_y]
 }
 
 // LIST DERIVATION: tab_summaries -----------------------------------------------

--- a/docs/plans/25-filter-activities-by-location.md
+++ b/docs/plans/25-filter-activities-by-location.md
@@ -1,0 +1,173 @@
+# 25. Filter the activity list by location
+
+> **Status: ✅ Done 2026-07-26** (implemented as designed. No migration or write
+> path touched — `location_id` is now emitted on the activity summary and the
+> client filters client-side via a searchable multi-select in the "More filters"
+> panel. Verified in a Gleam 1.16.0 container: shared 11 tests pass, client 131
+> tests pass (incl. 3 new `apply_filters` location cases), server type-checks
+> clean. Not yet committed — `gleam format` normalization pending on commit.)
+
+## Context
+
+The "More filters" panel already filters the activity list by **tags** and
+**målgrupp** (target groups) — see plan 08. There is no way to narrow the list
+to a **location**, even though every activity already links to one and the
+detail page renders it.
+
+This plan adds a **location** filter to the same panel, mirroring the existing
+tag filter end-to-end. Filtering runs **client-side** over already-loaded
+summaries in [`apply_filters`](../../client/src/client.gleam) — exactly like the
+tag / target-group filters.
+
+## Why this is safe for existing data
+
+**No migration, no write path, no risk to existing activities.**
+
+- Activities **already** store `location_id` (a nullable FK): the detail page
+  fetches and renders the full `Location`. Nothing about how activities are
+  stored, created, or updated changes.
+- The client **already** fetches the full locations vocabulary once on init
+  (`Model.locations: Dict(Uuid, Location)`, from `/api/locations`) and uses it
+  for the activity-form location picker — so the filter UI needs no new fetch.
+- The only server change is **read-only**: the slim list summary
+  (`summary_to_json`) currently emits `location_name` but not `location_id`;
+  we add the id so the client can filter by it. This is purely additive JSON.
+
+The entire feature is additive read + display. It touches no SQL, no migration,
+no create/update/delete handler.
+
+## Design
+
+Mirror the tag filter (ids on the summary → client filters by id via
+`lists_intersect`-style membership → resolve id to a label via the already-
+fetched vocabulary), with **one deliberate difference in the UI**: with ~70
+locations a flat chip row (as tags/målgrupp use) is unusable, so the location
+filter is a **searchable multi-select** (decided with the user). It reuses the
+form's combobox pattern (`view_location_picker`) but toggles membership and
+renders the selected locations as removable chips above the field.
+
+## Changes
+
+### 1. Server — expose `location_id` on the summary (read-only)
+
+`server/src/server/model/activity.gleam`, `summary_to_json` (~line 512):
+add one field next to the existing `location_name` (both derive from the
+`location` already destructured in scope):
+
+```gleam
+#(
+  "location_id",
+  json.nullable(location |> option.map(fn(l) { l.id }), uuid_to_json),
+),
+```
+
+`server/priv/openapi.yaml`: add `location_id` (nullable UUID) to the
+`ActivitySummary` response schema, per the server API-changes convention.
+
+### 2. Shared — carry it on the type
+
+`shared/src/shared/model.gleam`, `ActivitySummary` (line 238) and
+`activity_summary_decoder` (line 265):
+
+- Add field `location_id: Option(Uuid)` (keep `location_name` for card display).
+- Decode with
+  `decode.optional_field("location_id", None, decode.optional(uuid_decoder()))`.
+- Add `location_id:` to **both** the `decode.success` and the `decode.failure`
+  fallback `ActivitySummary(...)` constructors.
+
+### 3. Client — filter state + logic (`client/src/client.gleam`)
+
+- `ListFilters` (line 893): add `locations: List(Uuid)`. Seed `[]` in
+  `default_filters` (line 903). Add it to the recurring-tab reset inside
+  `apply_filters` (line 7430):
+  `ListFilters(..f, search: "", target_groups: [], tags: [], locations: [])`.
+- New message `UserToggledLocation(Uuid)` with a handler mirroring
+  `UserToggledTag` (line 2976) — **list-filter branch only**. Unlike
+  target-groups/tags, there is **no** activity-form branch: the form's location
+  picker is a separate single-select (`UserSelectedLocation`). Handler:
+  `update_filters(model, fn(f) { ListFilters(..f, locations: toggle_member(f.locations, id)) })`.
+- Transient picker UI state (search query + open/closed) is UI-only, so it lives
+  on the `Model`, not in `ListFilters` (which persists per page). Add a small
+  record — e.g. `location_filter_ui: LocationPickerUi(query: String, open: Bool)`
+  — initialised in `init`, mirroring how the form keeps its picker state in
+  `edit_ui` (`location_query` / `location_open`). Add messages
+  `UserSearchedLocationFilter(String)`, `UserOpenedLocationFilter`,
+  `UserClosedLocationFilter` with handlers copied from the form's
+  `UserSearchedLocation` / `UserOpenedLocationDropdown` /
+  `UserClosedLocationDropdown` (lines 3022–3059) but writing to
+  `location_filter_ui`.
+- `apply_filters` (line 7421): add a `location_match` and `&&` it in:
+
+  ```gleam
+  let location_match = case f.locations {
+    [] -> True
+    selected ->
+      summary.location_id
+      |> option.map(list.contains(selected, _))
+      |> option.unwrap(False)
+  }
+  ```
+
+  (Activities with no location are excluded whenever a location filter is
+  active — same intuition as the tag filter.)
+
+### 4. Client — filter UI (searchable multi-select)
+
+- `view_more_filters_panel` (line 4805) currently receives `activity_tags`; also
+  pass the `locations` dict and the `location_filter_ui` state through from its
+  call site (`view_activities_list`, line 4529, which already has `locations` in
+  scope at line 4438). Add a third section under the tag chips.
+- Add `view_location_multi_picker` next to `view_location_picker` (line 4886),
+  reusing its `matches` (name-sorted, query-filtered) and `option_button`
+  helpers. Differences from the single-select:
+  - Options **toggle** membership (`UserToggledLocation(id)`) and the list stays
+    open; the checked state is `list.contains(selected, id)`.
+  - Selected locations render **above** the field as removable
+    `component.filter_chip`s (click removes) so choices stay visible while the
+    dropdown filters the full ~70.
+  - No "no location" clear-entry (that concept is form-only); a "clear all"
+    affordance is optional.
+- Add `list.filter.location_label` translation keys (sv "Plats" / en "Location")
+  near the existing `list.filter.tags_label` block.
+
+### 5. Tests (`client/test/client_test.gleam`)
+
+- `base_summary` (line 45) gains `location_id: None`.
+- New `apply_filters` cases (pure, no DB):
+  - a selected location keeps only activities whose `location_id` matches;
+  - with a location filter active, an activity whose `location_id` is `None` is
+    dropped;
+  - empty `locations` keeps everything (regression: existing default test still
+    passes once the field is added);
+  - the recurring-tab reset clears an active location filter.
+
+## Out of scope
+
+- Server-side location filtering / a `?location=` query param — filtering stays
+  client-side over the loaded window, consistent with tags and search.
+- Persisting the location filter across navigation (tags/target-groups/search
+  already reset on navigation; location matches that behaviour — see plan 12).
+- Managing the location vocabulary from this screen (locations CRUD already
+  exists at `/api/locations`).
+
+## Verification
+
+1. `gleam format` + `gleam test` in `shared/`, `server/`, `client/` — all green
+   (new `apply_filters` regressions included).
+2. `./start.sh` (server on :8000, `DEV_AUTH_ROLES=admin`), then in the browser:
+   - `GET /api/activities?...` summaries now include `location_id`.
+   - "More filters" → search a location, select two → the list narrows to
+     activities at those locations; selected chips show above the field and
+     remove on click; activities with no location disappear.
+   - Switching to a recurring tab (Badbuss/Klättervägg) ignores the location
+     filter (reset), consistent with search/tags.
+3. Run `gleam-reviewer` on changed server/shared files and check the client
+   against `lustre-guide` / `web-components` conventions.
+
+## Notes / risks
+
+- Because there is no migration and no write path, the risk to existing
+  activities is effectively nil; the worst case is a display bug in the new
+  panel section, isolated from booking/activity data.
+- `summary_to_json` builds `location_id` from the `Activity.location` already in
+  scope — no new query and no change to the row → `Activity` conversions.

--- a/docs/plans/CLAUDE.md
+++ b/docs/plans/CLAUDE.md
@@ -50,3 +50,4 @@ When you create, finish, or touch a plan here, keep the folder consistent:
 | 22 | [Seed bookings only on capped activities](22-seed-bookings-only-on-capped-activities.md) | 🔲 Not started |
 | 23 | [Anonymous browsing: activities load without login (issue #20)](23-anonymous-browse.md) | ✅ Done 2026-07-20 |
 | 24 | [Bulk edit beach bus & climbing wall shared fields (issue #31)](24-bulk-edit-recurring-activities.md) | ✅ Done 2026-07-20 |
+| 25 | [Filter the activity list by location](25-filter-activities-by-location.md) | ✅ Done 2026-07-26 |

--- a/server/priv/openapi.yaml
+++ b/server/priv/openapi.yaml
@@ -2129,6 +2129,12 @@ components:
           description: The location's name in both languages (null if the activity has no location). The client selects a variant by active language.
           allOf:
             - $ref: '#/components/schemas/BilingualString'
+        location_id:
+          type: string
+          format: uuid
+          nullable: true
+          description: Id of the location this activity happens at (null if it has no location); resolve to the full location via `/locations`. Carried on the summary so list views can filter by location without fetching each activity's detail.
+          example: "b7a3559f-8f1a-4a3e-9d8e-2f6c1f1a2b3c"
         tags:
           type: array
           description: Ids of the activity tags applied to this activity (resolve them via `/activity-tags`). Carried on the summary so list views can filter without fetching each activity's detail.

--- a/server/src/server/model/activity.gleam
+++ b/server/src/server/model/activity.gleam
@@ -544,6 +544,12 @@ pub fn summary_to_json(activity: Activity) -> Json {
         model.bilingual_string_to_json,
       ),
     ),
+    // The location's id (alongside its name) so the list view can filter by
+    // location without fetching each activity's detail — mirrors `tags`.
+    #(
+      "location_id",
+      json.nullable(location |> option.map(fn(l) { l.id }), uuid_to_json),
+    ),
     #("tags", json.array(tags, uuid_to_json)),
     #("target_groups", json.array(target_groups, model.target_group_to_json)),
     #("cancellation", json.nullable(cancellation, json.string)),

--- a/shared/src/shared/model.gleam
+++ b/shared/src/shared/model.gleam
@@ -252,6 +252,10 @@ pub type ActivitySummary {
     /// The location's name in both languages, embedded so list cards need no
     /// follow-up request. `None` when the activity has no location.
     location_name: Option(BilingualString),
+    /// Id of the location this activity happens at (resolve via `/api/locations`).
+    /// Carried on the summary so the list view can filter by location without
+    /// fetching each activity's detail. `None` when the activity has no location.
+    location_id: Option(Uuid),
     /// Ids of the activity tags applied to this activity. Carried on the summary
     /// so the list view can filter without fetching each activity's detail.
     tags: List(Uuid),
@@ -290,6 +294,11 @@ pub fn activity_summary_decoder() -> decode.Decoder(ActivitySummary) {
     None,
     decode.optional(bilingual_string_decoder()),
   )
+  use location_id <- decode.optional_field(
+    "location_id",
+    None,
+    decode.optional(uuid_decoder()),
+  )
   use tags <- decode.optional_field(
     "tags",
     [],
@@ -319,6 +328,7 @@ pub fn activity_summary_decoder() -> decode.Decoder(ActivitySummary) {
         start_time: timestamp.from_unix_seconds(start_time_secs),
         end_time: timestamp.from_unix_seconds(end_time_secs),
         location_name:,
+        location_id:,
         tags:,
         target_groups:,
         cancellation:,
@@ -333,6 +343,7 @@ pub fn activity_summary_decoder() -> decode.Decoder(ActivitySummary) {
           start_time: timestamp.from_unix_seconds(start_time_secs),
           end_time: timestamp.from_unix_seconds(end_time_secs),
           location_name:,
+          location_id:,
           tags:,
           target_groups:,
           cancellation:,


### PR DESCRIPTION
Add a location filter to the activity list "More filters" panel, mirroring the existing tag/målgrupp filters. Filtering runs client-side over the loaded summaries, so there is no migration and no write path — activities already store location_id and the client already fetches the locations vocabulary.

- server: emit location_id on the activity summary JSON (read-only), alongside the existing location_name; document it in openapi.yaml.
- shared: carry location_id: Option(Uuid) on ActivitySummary + decoder.
- client: ListFilters.locations, a location_match clause in apply_filters, a LocationFilterUi transient-state type on the Model, toggle/search/open/close messages and handlers, and a searchable multi-select combobox in the panel (selected locations show as removable chips). sv/en translations added.
- tests: apply_filters keeps only matching locations, excludes location-less activities when a filter is active, and ignores the filter on recurring tabs.

See docs/plans/25-filter-activities-by-location.md.