### PR TITLE
feat(api): location filter offers only locations with an activity

### DIFF
--- a/client/src/client.gleam
+++ b/client/src/client.gleam
@@ -1141,9 +1141,17 @@ pub type Model {
     // loaded (and if the fetch fails), in which case tag chips simply don't show.
     activity_tags: Dict(Uuid, ActivityTag),
     // Location vocabulary, keyed by id, fetched once from /api/locations. Feeds
-    // the create/edit form's location picker. Empty until loaded (and if the
-    // fetch fails), in which case the picker shows only the "no location" option.
+    // the create/edit form's location picker, which must be able to assign any
+    // location. Empty until loaded (and if the fetch fails), in which case the
+    // picker shows only the "no location" option.
     locations: Dict(Uuid, Location),
+    // Locations that at least one activity references, keyed by id, fetched once
+    // from /api/locations?has_activities=true. Feeds ONLY the activity list's
+    // location filter, so facility-only locations (toilets, …) aren't offered as
+    // filter options (filtering by them could only ever yield nothing). Empty
+    // until loaded (and if the fetch fails), in which case the filter offers no
+    // options.
+    filter_locations: Dict(Uuid, Location),
     // The current user's roles, gating manage-only UI (edit, view bookings).
     roles: List(Role),
     // Whether the visitor is logged in at all, from /api/me (401 = Anonymous).
@@ -2230,6 +2238,7 @@ fn init(_flags) -> #(Model, Effect(Msg)) {
       spots: dict.new(),
       activity_tags: dict.new(),
       locations: dict.new(),
+      filter_locations: dict.new(),
       // Empty until /api/me returns; the role-gated UI reveals once loaded.
       roles: [],
       session: SessionUnknown,
@@ -2270,6 +2279,7 @@ fn init(_flags) -> #(Model, Effect(Msg)) {
       fetch_spots(),
       fetch_activity_tags(),
       fetch_locations(),
+      fetch_filter_locations(),
       page_effect,
       overview_effect,
       // Always attempt; a 401 (anonymous user) leaves the status dict empty.
@@ -2299,6 +2309,7 @@ pub type Msg {
   ApiReturnedActivitySpotsOne(Uuid, Result(Int, rsvp.Error))
   ApiReturnedActivityTags(Result(List(ActivityTag), rsvp.Error))
   ApiReturnedLocations(Result(List(Location), rsvp.Error))
+  ApiReturnedFilterLocations(Result(List(Location), rsvp.Error))
   ApiReturnedScoutGroups(Result(List(ScoutGroup), rsvp.Error))
   ApiCreatedActivity(Result(Activity, rsvp.Error))
   ApiUpdatedActivity(Result(Activity, rsvp.Error))
@@ -2623,6 +2634,18 @@ pub fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
     // Keep the prior vocabulary (empty) on failure; the picker just shows the
     // "no location" option only.
     ApiReturnedLocations(Error(_)) -> #(model, effect.none())
+
+    ApiReturnedFilterLocations(Ok(locations)) -> {
+      let filter_locations =
+        list.fold(locations, dict.new(), fn(acc, location) {
+          dict.insert(acc, location.id, location)
+        })
+      #(Model(..model, filter_locations:), effect.none())
+    }
+
+    // Keep the prior vocabulary (empty) on failure; the location filter just
+    // offers no options.
+    ApiReturnedFilterLocations(Error(_)) -> #(model, effect.none())
 
     ApiReturnedScoutGroups(Ok(scout_groups)) -> #(
       Model(..model, scout_groups: Loaded(scout_groups)),
@@ -4460,6 +4483,16 @@ fn fetch_locations() -> Effect(Msg) {
   )
 }
 
+/// The location vocabulary for the activity list's location filter: only
+/// locations an activity references (filtered in the database via
+/// `has_activities`, not here), so facility-only locations aren't offered.
+fn fetch_filter_locations() -> Effect(Msg) {
+  rsvp.get(
+    api_prefix <> "/api/locations?has_activities=true",
+    rsvp.expect_json(model.locations_decoder(), ApiReturnedFilterLocations),
+  )
+}
+
 fn delete_activity(id: Uuid) -> Effect(Msg) {
   rsvp.delete(
     api_prefix <> "/api/activities/" <> uuid.to_string(id),
@@ -4782,6 +4815,7 @@ fn view(model: Model) -> Element(Msg) {
         model.list_warning_dismissed,
         model.edit_ui,
         model.locations,
+        model.filter_locations,
         model.location_filter_ui,
         model.session,
       )
@@ -4836,6 +4870,7 @@ fn view_activities_list(
   warning_dismissed: Bool,
   edit_ui: EditUi,
   locations: Dict(Uuid, Location),
+  filter_locations: Dict(Uuid, Location),
   location_filter_ui: LocationFilterUi,
   session: Session,
 ) -> Element(Msg) {
@@ -4879,7 +4914,7 @@ fn view_activities_list(
           translator,
           filters,
           activity_tags,
-          locations,
+          filter_locations,
           location_filter_ui,
         )
       False -> element.none()
@@ -5134,7 +5169,7 @@ fn view_more_filters_panel(
   translator: Translator,
   filters: ListFilters,
   activity_tags: Dict(Uuid, ActivityTag),
-  locations: Dict(Uuid, Location),
+  filter_locations: Dict(Uuid, Location),
   location_filter_ui: LocationFilterUi,
 ) -> Element(Msg) {
   html.div(
@@ -5153,7 +5188,7 @@ fn view_more_filters_panel(
       [
         view_location_filter(
           translator,
-          locations,
+          filter_locations,
           filters.locations,
           location_filter_ui,
         ),

--- a/client/src/client.gleam
+++ b/client/src/client.gleam
@@ -5711,7 +5711,10 @@ fn card_status(
 
 /// Localized validation error messages for the activity form (formal's built-in
 /// messages are English only). Applied via `form.language` in the form view.
-fn form_error_message(translator: Translator, error: form.FieldError) -> String {
+fn form_error_message(
+  translator: Translator,
+  error: form.FieldError,
+) -> String {
   let t = fn(key) { g18n.translate(translator, key) }
   case error {
     form.MustBePresent -> t("form.error.required")

--- a/client/src/component.gleam
+++ b/client/src/component.gleam
@@ -45,10 +45,9 @@ fn field_with_errors(
 }
 
 fn field_error(message: String) -> Element(msg) {
-  html.small(
-    [attribute.styles([#("color", "var(--color-text-danger-base)")])],
-    [element.text(message)],
-  )
+  html.small([attribute.styles([#("color", "var(--color-text-danger-base)")])], [
+    element.text(message),
+  ])
 }
 
 /// A labelled, non-editable `scout-input` showing a fixed value. Used for

--- a/client/test/client_test.gleam
+++ b/client/test/client_test.gleam
@@ -167,6 +167,7 @@ fn base_model() -> client.Model {
     spots: dict.new(),
     activity_tags: dict.new(),
     locations: dict.new(),
+    filter_locations: dict.new(),
     roles: [client.ManageActivities],
     session: client.SessionUnknown,
     booker: client.IdentityUnknown,

--- a/docs/plans/27-location-filter-only-locations-with-activities.md
+++ b/docs/plans/27-location-filter-only-locations-with-activities.md
@@ -1,0 +1,97 @@
+# 27. Location filter offers only locations that have an activity
+
+> **Status: 🚧 In progress** (as of 2026-07-27) — code complete on branch
+> `feat/filter-locations-with-activities`; pending `gleam run -m squirrel`
+> (regenerates `sql.gleam` for the new query param), `gleam format`, tests, and
+> commit.
+
+## Context
+
+Plan [25](25-filter-activities-by-location.md) added the activity list's
+location filter (a searchable multi-select in the "More filters" panel). It
+populates its options from `Model.locations` — the **full** location vocabulary
+fetched from `/api/locations`, the same dict the create/edit activity form's
+location picker uses. That vocabulary includes facility-only locations (toilets,
+info points, …) that no activity references. Offering those as **filter** options
+is useless: filtering the list by a location with no activities can only ever
+yield nothing.
+
+Requirement (from the product owner): the **filter** should offer only
+locations that have at least one activity, while the create/edit **form picker**
+must still offer **every** location (so an activity can be assigned to any
+location, including one that has none yet). The set of "locations with an
+activity" should come from the database, not be computed in the frontend, and
+should reflect **all** activities — not just the summaries currently loaded in
+the browser.
+
+## Design
+
+Split the two consumers onto two vocabularies:
+
+- **Form picker** → `Model.locations`, from `GET /api/locations` (all locations).
+  Unchanged.
+- **List filter** → new `Model.filter_locations`, from
+  `GET /api/locations?has_activities=true` (only locations an activity
+  references).
+
+Filtering itself is unchanged (client-side over `summary.location_id`, per plan
+25). Only the **option list** the filter offers changes. An already-selected
+location that later loses its activities keeps filtering as before — it just
+won't be offered again (decided with the user); filters reset on navigation
+anyway (plan 12/26), so this is a negligible race.
+
+## Changes
+
+### Server — `has_activities` query param on `GET /api/locations` (read-only)
+
+- `server/src/server/sql/list_locations.sql`: add a boolean param `$1`; return
+  all rows when false, else only locations with a referencing activity via
+  `WHERE NOT $1 OR EXISTS (SELECT 1 FROM activity WHERE activity.location_id = location.id)`.
+  This is the DB equivalent of `SELECT DISTINCT a.location_id … FROM activity a
+  JOIN location l …`, returning full `Location` rows so the combobox can render
+  names. **Requires `gleam run -m squirrel`** to regenerate `sql.gleam`
+  (`list_locations` gains a `Bool` argument).
+- `server/src/server/model/location.gleam`: `fetch_all` gains
+  `only_with_activities: Bool` and threads it into `sql.list_locations`.
+  `fetch_all_dict` (embeds locations into activities) passes `False` — embedding
+  must never drop a referenced location.
+- `server/src/server/web/location.gleam`: `get_all` reads the optional
+  `has_activities` query param (default `false`, 400 on a bad value) via the
+  existing `web.ensure_valid_query_param` helper; added a local `parse_bool`.
+- `server/priv/openapi.yaml`: document the new query parameter (per the server
+  API-changes convention).
+
+No migration, no write path, no schema change: `activity.location_id` (and its
+index) already exist.
+
+### Client — a second vocabulary for the filter (`client/src/client.gleam`)
+
+- `Model`: add `filter_locations: Dict(Uuid, Location)`, initialised empty.
+- `init`: dispatch a new `fetch_filter_locations()` effect
+  (`GET /api/locations?has_activities=true`) alongside the existing
+  `fetch_locations()`.
+- New message `ApiReturnedFilterLocations(Result(List(Location), rsvp.Error))`
+  with a handler folding rows into `filter_locations` (mirrors
+  `ApiReturnedLocations`); failure keeps the empty vocabulary (filter offers no
+  options).
+- View plumbing: thread `filter_locations` from `view` → `view_activities_list`
+  → `view_more_filters_panel` → `view_location_filter`. The form drawer
+  (`view_activity_form_drawer`) keeps receiving the full `locations`.
+
+## Verification
+
+1. `cd server && gleam run -m squirrel` (needs `DATABASE_URL` up), then
+   `gleam format` + `gleam test` in `shared/`, `server/`, `client/`.
+2. `./start.sh`, then in the browser:
+   - Create/edit an activity → the form's location picker still lists **every**
+     location (toilets included).
+   - "More filters" → the location filter lists **only** locations that have an
+     activity; toilets etc. are absent.
+   - `GET /api/locations` returns all; `GET /api/locations?has_activities=true`
+     returns the reduced set; a bad value (`?has_activities=nope`) is a 400.
+
+## Out of scope
+
+- Server-side filtering of the activity list itself (still client-side, plan 25).
+- Resolving a selected-but-now-empty location's chip label from the full
+  vocabulary (negligible race; filters reset on navigation).

--- a/docs/plans/CLAUDE.md
+++ b/docs/plans/CLAUDE.md
@@ -52,3 +52,4 @@ When you create, finish, or touch a plan here, keep the folder consistent:
 | 24 | [Bulk edit beach bus & climbing wall shared fields (issue #31)](24-bulk-edit-recurring-activities.md) | ✅ Done 2026-07-20 |
 | 25 | [Filter the activity list by location](25-filter-activities-by-location.md) | ✅ Done 2026-07-26 |
 | 26 | [Activity-list filters live in the URL (Back restores them)](26-filters-in-the-url.md) | ✅ Done 2026-07-26 |
+| 27 | [Location filter offers only locations that have an activity](27-location-filter-only-locations-with-activities.md) | 🚧 In progress |

--- a/server/priv/openapi.yaml
+++ b/server/priv/openapi.yaml
@@ -1512,10 +1512,25 @@ paths:
         - Locations
       summary: List locations
       description: |
-        Retrieve all map locations, ordered by name. Each location embeds the
+        Retrieve map locations, ordered by name. Each location embeds the
         ids of its tags (resolve them via `/location-tags`) and its opening
         hours keyed by ISO date. Not paginated.
+
+        By default every location is returned. Set `has_activities=true` to
+        return only locations referenced by at least one activity — the
+        activity list's location filter uses this to avoid offering
+        facility-only locations (toilets, info points, …) that no activity uses.
       operationId: listLocations
+      parameters:
+        - name: has_activities
+          in: query
+          required: false
+          description: |
+            When `true`, only locations referenced by at least one activity are
+            returned. Defaults to `false` (all locations).
+          schema:
+            type: boolean
+            default: false
       responses:
         '200':
           description: Successfully retrieved locations

--- a/server/src/server/model/location.gleam
+++ b/server/src/server/model/location.gleam
@@ -169,9 +169,18 @@ pub fn group_tags_by_location(
   })
 }
 
-/// Fetch every location with its tag ids stitched in, ordered by name.
-pub fn fetch_all(db: pog.Connection) -> Result(List(Location), pog.QueryError) {
-  use pog.Returned(_, location_rows) <- result.try(sql.list_locations(db))
+/// Fetch locations with their tag ids stitched in, ordered by name. When
+/// `only_with_activities` is `True`, locations that no activity references are
+/// excluded (see `list_locations.sql`); when `False`, every location is
+/// returned.
+pub fn fetch_all(
+  db: pog.Connection,
+  only_with_activities: Bool,
+) -> Result(List(Location), pog.QueryError) {
+  use pog.Returned(_, location_rows) <- result.try(sql.list_locations(
+    db,
+    only_with_activities,
+  ))
   use pog.Returned(_, link_rows) <- result.try(sql.list_location_tag_links(db))
   let tags_by_location = group_tags_by_location(link_rows)
   location_rows
@@ -187,7 +196,8 @@ pub fn fetch_all(db: pog.Connection) -> Result(List(Location), pog.QueryError) {
 pub fn fetch_all_dict(
   db: pog.Connection,
 ) -> Result(Dict(Uuid, Location), pog.QueryError) {
-  use locations <- result.map(fetch_all(db))
+  // Embedding needs every referenced location, so it never filters.
+  use locations <- result.map(fetch_all(db, False))
   list.fold(locations, dict.new(), fn(acc, location) {
     dict.insert(acc, location.id, location)
   })

--- a/server/src/server/sql/list_locations.sql
+++ b/server/src/server/sql/list_locations.sql
@@ -1,5 +1,11 @@
--- Lists all locations ordered by name. `opening_hours` (jsonb) comes back as
--- its JSON text, which Squirrel maps to a String for the model layer to parse.
+-- Lists locations ordered by name. `opening_hours` (jsonb) comes back as its
+-- JSON text, which Squirrel maps to a String for the model layer to parse.
+--
+-- When $1 is true, only locations referenced by at least one activity are
+-- returned — the activity list's location filter uses this so facility-only
+-- locations (toilets, info points, …) that no activity links to aren't offered.
+-- When $1 is false, every location is returned (e.g. the activity form's
+-- location picker, which must be able to assign any location).
 SELECT id,
     name,
     name_en,
@@ -12,4 +18,10 @@ SELECT id,
     longitude,
     opening_hours
 FROM location
+WHERE NOT $1
+    OR EXISTS (
+        SELECT 1
+        FROM activity
+        WHERE activity.location_id = location.id
+    )
 ORDER BY name ASC;

--- a/server/src/server/web/location.gleam
+++ b/server/src/server/web/location.gleam
@@ -86,12 +86,24 @@ fn location_tag_input_decoder() -> decode.Decoder(LocationTagInput) {
 
 // --- Locations -------------------------------------------------------------
 
-/// Returns all locations with their tag ids embedded. Locations and their
+/// Returns locations with their tag ids embedded. Locations and their
 /// join-table links are fetched separately and stitched together in
 /// `location.fetch_all`, avoiding an array aggregation in SQL.
+///
+/// The optional `has_activities` query param (default `false`) narrows the list
+/// to locations referenced by at least one activity — the client's activity
+/// list location filter sets it so facility-only locations (toilets, …) that no
+/// activity uses aren't offered as filter options. A malformed value is a 400.
 pub fn get_all(req: Request, ctx: web.Context) -> Response {
   use <- wisp.require_method(req, Get)
-  case location.fetch_all(ctx.db_connection) {
+  use has_activities <- web.ensure_valid_query_param(
+    in: wisp.get_query(req),
+    with_name: "has_activities",
+    if_missing_return: False,
+    using: parse_bool,
+    else_respond_with: "Invalid has_activities parameter. Allowed values: true, false",
+  )
+  case location.fetch_all(ctx.db_connection, has_activities) {
     Error(error) -> web.query_error(error)
     Ok(locations) ->
       wisp.json_response(
@@ -444,4 +456,12 @@ pub fn delete_tag(req: Request, id: String, ctx: web.Context) -> Response {
 fn transaction_error(error: pog.TransactionError(pog.QueryError)) -> Response {
   wisp.log_error("TransactionError " <> string.inspect(error))
   wisp.internal_server_error()
+}
+
+fn parse_bool(value: String) -> Result(Bool, Nil) {
+  case value {
+    "true" -> Ok(True)
+    "false" -> Ok(False)
+    _ -> Error(Nil)
+  }
 }


### PR DESCRIPTION
The activity list's location filter listed the full location vocabulary (toilets, info points, …) — even locations no activity references, which can only ever filter to nothing. Add an opt-in `has_activities=true` query param to `GET /api/locations` (filtered in the database) and give the filter its own vocabulary, while the create/edit form's location picker keeps listing every location.

- sql/list_locations.sql: boolean param to restrict to locations with a referencing activity
- model/location.gleam: `fetch_all` takes `only_with_activities`; `fetch_all_dict` passes `False` (embedding must keep every location)
- web/location.gleam: `get_all` reads `has_activities` (default false, 400 on a bad value)
- client: new `Model.filter_locations` fed to the filter panel; the form drawer keeps the full `locations` list

Follow-up before this compiles: `gleam run -m squirrel` (regenerates sql.gleam for the new param) + `gleam format` — neither run here.