### PR TITLE
feat(api): badbuss departure check-offs per kår

### DIFF
--- a/client/src/client.gleam
+++ b/client/src/client.gleam
@@ -33,8 +33,9 @@ import shared/event as event_dates
 import shared/model.{
   type Activity, type ActivitySpots, type ActivityStatus,
   type ActivityStatusEntry, type ActivitySummary, type ActivityTag, type Booking,
-  type BookingSlot, type GroupCount, type Location, type ScoutGroup,
-  type TargetGroup, Booked, Favourited, NotInterested,
+  type BookingSlot, type GroupCount, type Location, type RecurringKind,
+  type ScoutGroup, type TargetGroup, BeachBus, Booked, ClimbingWall, Favourited,
+  NotInterested,
 }
 import youid/uuid.{type Uuid}
 
@@ -184,6 +185,10 @@ fn english_translations() -> g18n.Translations {
   )
   |> g18n.add_translation("bookings.participants.one", "{count} person")
   |> g18n.add_translation("bookings.participants.other", "{count} people")
+  // Badbuss departure check-offs — beach bus slots only.
+  |> g18n.add_translation("bookings.departures_heading", "Departures")
+  |> g18n.add_translation("bookings.left_campsite", "Left the campsite")
+  |> g18n.add_translation("bookings.left_beach", "Left the beach")
   |> g18n.add_translation("list.search_placeholder", "Search")
   |> g18n.add_translation("list.filter.all", "All")
   |> g18n.add_translation("list.tab.activities", "Activities")
@@ -230,6 +235,10 @@ fn english_translations() -> g18n.Translations {
   |> g18n.add_translation("error.cancel_booking", "Failed to cancel booking")
   |> g18n.add_translation("error.restore_booking", "Failed to restore booking")
   |> g18n.add_translation("error.load_bookings", "Failed to load bookings")
+  |> g18n.add_translation(
+    "error.set_departure",
+    "Could not save the check-off — try again",
+  )
   |> g18n.add_translation(
     "error.booking_group_required",
     "Choose a corps to book for",
@@ -385,6 +394,10 @@ fn swedish_translations() -> g18n.Translations {
   )
   |> g18n.add_translation("bookings.participants.one", "{count} person")
   |> g18n.add_translation("bookings.participants.other", "{count} personer")
+  // Badbuss departure check-offs — badbusspass only.
+  |> g18n.add_translation("bookings.departures_heading", "Avfärd")
+  |> g18n.add_translation("bookings.left_campsite", "Lämnat lägerplatsen")
+  |> g18n.add_translation("bookings.left_beach", "Lämnat stranden")
   |> g18n.add_translation("list.search_placeholder", "Sök")
   |> g18n.add_translation("list.filter.all", "Alla")
   |> g18n.add_translation("list.tab.activities", "Aktiviteter")
@@ -449,6 +462,10 @@ fn swedish_translations() -> g18n.Translations {
     "Kunde inte uppdatera bokningen",
   )
   |> g18n.add_translation("error.load_bookings", "Kunde inte ladda bokningarna")
+  |> g18n.add_translation(
+    "error.set_departure",
+    "Kunde inte spara markeringen — försök igen",
+  )
   |> g18n.add_translation(
     "error.booking_group_required",
     "Välj en kår att boka åt",
@@ -801,6 +818,8 @@ pub type AppError {
   BookingGroupRequired
   LoadBookingsFailed
   LoadScoutGroupsFailed
+  /// A badbuss departure check-off could not be saved; the tick was rolled back.
+  SetDepartureFailed
 }
 
 fn app_error_key(error: AppError) -> String {
@@ -821,6 +840,7 @@ fn app_error_key(error: AppError) -> String {
     LoadBookingsFailed -> "error.load_bookings"
     // Surfaced inside the kår picker; reuses the bookings-load message.
     LoadScoutGroupsFailed -> "error.load_bookings"
+    SetDepartureFailed -> "error.set_departure"
   }
 }
 
@@ -981,15 +1001,6 @@ pub fn tab_has_search_and_filters(tab: ActivitiesFilterTab) -> Bool {
   }
 }
 
-/// A kind of recurring activity that gets its own booking-overview page
-/// (Badbuss / Klättervägg). Both pages share one view, differing only in which
-/// slots they load and their heading; the kind also maps to the server's
-/// `recurring_activity_kind` and picks the overview endpoint.
-pub type RecurringKind {
-  BeachBus
-  ClimbingWall
-}
-
 /// Identity of a cached overview: which recurring kind and which event day. Both
 /// the slot window and its revalidation ETag are keyed by this, so each
 /// `(kind, day)` caches and revalidates independently — switching day shows the
@@ -997,6 +1008,44 @@ pub type RecurringKind {
 /// list's `WindowKey`).
 pub type RecurringKey =
   #(RecurringKind, calendar.Date)
+
+/// The two boarding stages the badbuss staff tick off per kår on a slot's
+/// bookings view: the kår has left the campsite, and later the beach. Two
+/// independent flags on the booking, each with its own endpoint, so ticking one
+/// can never overwrite the other.
+pub type DepartureStage {
+  LeftCampsite
+  LeftBeach
+}
+
+/// The `PUT /api/bookings/:id/…` path segment that writes a stage.
+fn departure_stage_path(stage: DepartureStage) -> String {
+  case stage {
+    LeftCampsite -> "left-campsite"
+    LeftBeach -> "left-beach"
+  }
+}
+
+/// A stage's current value on a booking.
+fn departure_stage_value(booking: Booking, stage: DepartureStage) -> Bool {
+  case stage {
+    LeftCampsite -> booking.left_campsite
+    LeftBeach -> booking.left_beach
+  }
+}
+
+/// `booking` with one stage set — the optimistic tick, and the rollback when the
+/// write fails.
+fn set_departure_stage(
+  booking: Booking,
+  stage: DepartureStage,
+  checked: Bool,
+) -> Booking {
+  case stage {
+    LeftCampsite -> model.Booking(..booking, left_campsite: checked)
+    LeftBeach -> model.Booking(..booking, left_beach: checked)
+  }
+}
 
 /// The outcome of a (conditional) overview fetch, derived from the HTTP response
 /// in the effect handler so `update` never touches raw responses (parallels
@@ -1060,6 +1109,10 @@ pub type Page {
     id: Uuid,
     bookings: RemoteData(List(Booking)),
     booking_form: BookingFormState,
+    /// The last badbuss departure check-off that failed to save (the tick is
+    /// rolled back when it does), or `None`. Page-scoped because the check-offs
+    /// only exist here; cleared by the next successful tick or refetch.
+    departure_error: Option(AppError),
   )
   /// Booking overview for a recurring activity kind (Badbuss / Klättervägg): the
   /// slots for `selected_day` (default today), grouped by kår. The slots + ETag
@@ -1086,6 +1139,10 @@ pub type ActivityDetail {
     /// the edit form needs it (gating uses the summary's effective
     /// `booking_opens_at`).
     booking_opens_at_override: Option(Timestamp),
+    /// Which recurring kind this activity is a slot of, `None` for an ordinary
+    /// activity. Detail-only because only the bookings view needs it — that is
+    /// where `Some(BeachBus)` unlocks the badbuss departure check-offs.
+    recurring_kind: Option(RecurringKind),
   )
 }
 
@@ -1208,7 +1265,7 @@ fn set_activity_form(model: Model, activity_form: ActivityFormState) -> Model {
 fn page_booking_form(page: Page) -> Result(#(Uuid, BookingFormState), Nil) {
   case page {
     ActivityDetailPage(id, booking_form) -> Ok(#(id, booking_form))
-    ActivityBookingsPage(id, _, booking_form) -> Ok(#(id, booking_form))
+    ActivityBookingsPage(id, _, booking_form, _) -> Ok(#(id, booking_form))
     _ -> Error(Nil)
   }
 }
@@ -1223,8 +1280,50 @@ fn set_page_booking_form(
   case model.page {
     ActivityDetailPage(id, _) ->
       Model(..model, page: ActivityDetailPage(id, booking_form))
-    ActivityBookingsPage(id, bookings, _) ->
-      Model(..model, page: ActivityBookingsPage(id, bookings, booking_form))
+    ActivityBookingsPage(id, bookings, _, departure_error) ->
+      Model(
+        ..model,
+        page: ActivityBookingsPage(id, bookings, booking_form, departure_error),
+      )
+    _ -> model
+  }
+}
+
+/// Swap one booking in the bookings page's loaded list, matched by id. A no-op
+/// off that page, while its list is still loading, or when the booking isn't in
+/// it — all of which mean the response outlived what it was for.
+fn replace_page_booking(model: Model, booking: Booking) -> Model {
+  case model.page {
+    ActivityBookingsPage(id, Loaded(bookings), booking_form, departure_error) ->
+      Model(
+        ..model,
+        page: ActivityBookingsPage(
+          id,
+          Loaded(
+            list.map(bookings, fn(existing) {
+              case existing.id == booking.id {
+                True -> booking
+                False -> existing
+              }
+            }),
+          ),
+          booking_form,
+          departure_error,
+        ),
+      )
+    _ -> model
+  }
+}
+
+/// Set (or clear) the bookings page's departure check-off error. A no-op off
+/// that page — the check-offs only live there.
+fn set_departure_error(model: Model, error: Option(AppError)) -> Model {
+  case model.page {
+    ActivityBookingsPage(id, bookings, booking_form, _) ->
+      Model(
+        ..model,
+        page: ActivityBookingsPage(id, bookings, booking_form, error),
+      )
     _ -> model
   }
 }
@@ -1782,7 +1881,7 @@ fn seed_detail_loading(
   page: Page,
 ) -> Dict(Uuid, RemoteData(ActivityDetail)) {
   case page {
-    ActivityDetailPage(id, _) | ActivityBookingsPage(id, _, _) ->
+    ActivityDetailPage(id, _) | ActivityBookingsPage(id, _, _, _) ->
       case dict.get(details, id) {
         Ok(Loaded(_)) -> details
         _ -> dict.insert(details, id, Loading)
@@ -1813,6 +1912,7 @@ fn to_detail(a: Activity) -> ActivityDetail {
     description: a.description,
     location: a.location,
     booking_opens_at_override: a.booking_opens_at_override,
+    recurring_kind: a.recurring_kind,
   )
 }
 
@@ -1831,6 +1931,7 @@ fn to_activity(summary: ActivitySummary, detail: ActivityDetail) -> Activity {
     cancellation: summary.cancellation,
     booking_opens_at: summary.booking_opens_at,
     booking_opens_at_override: detail.booking_opens_at_override,
+    recurring_kind: detail.recurring_kind,
   )
 }
 
@@ -2190,7 +2291,7 @@ fn app_bar_title(translator: Translator, page: Page) -> Option(String) {
       Some(g18n.translate(translator, "app_bar.manage_activities"))
     ActivityDetailPage(_, _) ->
       Some(g18n.translate(translator, "app_bar.activity_detail"))
-    ActivityBookingsPage(_, _, _) ->
+    ActivityBookingsPage(_, _, _, _) ->
       Some(g18n.translate(translator, "app_bar.activity_bookings"))
     RecurringBookingsPage(BeachBus, _) ->
       Some(g18n.translate(translator, "app_bar.beach_bus_bookings"))
@@ -2322,6 +2423,15 @@ pub type Msg {
   ApiDeletedBooking(Uuid, Uuid, Result(Nil, rsvp.Error))
   ApiCancelledBooking(Uuid, Result(Booking, rsvp.Error))
   ApiRestoredBooking(Uuid, Result(Booking, rsvp.Error))
+  /// A badbuss departure check-off came back. `Ok` carries the saved booking,
+  /// which replaces the optimistically-ticked one; on `Error` the tick is rolled
+  /// back to `was` — the value the flag had before the click.
+  ApiSetBookingDeparture(
+    booking_id: Uuid,
+    stage: DepartureStage,
+    was: Bool,
+    result: Result(Booking, rsvp.Error),
+  )
   ApiReturnedBookings(Uuid, Result(List(Booking), rsvp.Error))
   ApiToggledFavourite(Uuid, Bool, Result(Nil, rsvp.Error))
   // Form submissions
@@ -2380,6 +2490,9 @@ pub type Msg {
   UserClickedConfirmCancelBooking
   UserClickedRestoreBookingCard(Uuid)
   UserClickedConfirmRestore
+  /// Ticked or unticked one of the two badbuss departure check-offs on a
+  /// booking card. Carries the box's new state.
+  UserToggledDeparture(booking_id: Uuid, stage: DepartureStage, checked: Bool)
   // Recurring-activity booking overview (Badbuss / Klättervägg)
   ApiReturnedRecurringBookings(RecurringKey, RecurringResult)
   UserSelectedOverviewDay(Option(calendar.Date))
@@ -3309,7 +3422,7 @@ pub fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
     // another user's, so my statuses can't supply it.
     UserClickedEditBookingCard(booking) ->
       case model.page {
-        ActivityBookingsPage(id, _, _) -> {
+        ActivityBookingsPage(id, _, _, _) -> {
           let max_attendees = case detail_of(model, id) {
             Loaded(activity) -> activity.max_attendees
             _ -> None
@@ -3340,7 +3453,7 @@ pub fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
     // Bookings page: ask for confirmation before unbooking a card's booking.
     UserClickedUnbookCard(booking_id) ->
       case model.page {
-        ActivityBookingsPage(_, _, _) -> #(
+        ActivityBookingsPage(_, _, _, _) -> #(
           set_page_booking_form(model, UnbookConfirming(booking_id)),
           effect.none(),
         )
@@ -3351,7 +3464,7 @@ pub fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
     // (issue #43).
     UserClickedCancelBookingCard(booking_id) ->
       case model.page {
-        ActivityBookingsPage(_, _, _) -> #(
+        ActivityBookingsPage(_, _, _, _) -> #(
           set_page_booking_form(
             model,
             CancelReasonEditing(booking_id, "", None),
@@ -3392,7 +3505,7 @@ pub fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
     // booking (issue #43).
     UserClickedRestoreBookingCard(booking_id) ->
       case model.page {
-        ActivityBookingsPage(_, _, _) -> #(
+        ActivityBookingsPage(_, _, _, _) -> #(
           set_page_booking_form(model, RestoreConfirming(booking_id)),
           effect.none(),
         )
@@ -3405,6 +3518,65 @@ pub fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
           set_page_booking_form(model, RestoreSubmitting(booking_id)),
           restore_booking(id, booking_id),
         )
+        _ -> #(model, effect.none())
+      }
+
+    // A badbuss departure check-off was ticked/unticked. The tick lands in the
+    // list immediately — a checkbox that waits for the network feels broken, and
+    // the model has to move in step with the component's own checked state — and
+    // the response either confirms it or rolls it back.
+    UserToggledDeparture(booking_id, stage, checked) ->
+      case model.page {
+        ActivityBookingsPage(_, Loaded(bookings), _, _) ->
+          case list.find(bookings, fn(b) { b.id == booking_id }) {
+            Ok(booking) -> {
+              let was = departure_stage_value(booking, stage)
+              // Nothing to do when the box already holds what was clicked (a
+              // re-render echoing our own optimistic write).
+              use <- bool.guard(when: was == checked, return: #(
+                model,
+                effect.none(),
+              ))
+              #(
+                model
+                  |> replace_page_booking(set_departure_stage(
+                    booking,
+                    stage,
+                    checked,
+                  ))
+                  |> set_departure_error(None),
+                set_booking_departure(booking_id, stage, checked, was),
+              )
+            }
+            Error(_) -> #(model, effect.none())
+          }
+        _ -> #(model, effect.none())
+      }
+
+    // The saved booking is authoritative — it also carries the *other* stage as
+    // stored, so a tick by someone else that we hadn't seen lands here too.
+    ApiSetBookingDeparture(_, _, _, Ok(booking)) -> #(
+      replace_page_booking(model, booking),
+      effect.none(),
+    )
+
+    // The write failed: put the tick back where it was and say so, rather than
+    // leaving a box claiming a kår has left when nothing was saved.
+    ApiSetBookingDeparture(booking_id, stage, was, Error(_)) ->
+      case model.page {
+        ActivityBookingsPage(_, Loaded(bookings), _, _) ->
+          case list.find(bookings, fn(b) { b.id == booking_id }) {
+            Ok(booking) -> #(
+              model
+                |> replace_page_booking(set_departure_stage(booking, stage, was))
+                |> set_departure_error(Some(SetDepartureFailed)),
+              effect.none(),
+            )
+            Error(_) -> #(
+              set_departure_error(model, Some(SetDepartureFailed)),
+              effect.none(),
+            )
+          }
         _ -> #(model, effect.none())
       }
 
@@ -3772,7 +3944,7 @@ pub fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
       let model = set_page_booking_form(model, BookingClosed)
       // The bookings page shows the live list, so refetch it after an edit.
       let refetch = case model.page {
-        ActivityBookingsPage(id, _, _) -> fetch_bookings(id)
+        ActivityBookingsPage(id, _, _, _) -> fetch_bookings(id)
         _ -> effect.none()
       }
       #(
@@ -3816,7 +3988,7 @@ pub fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
         remove_status_booking(model.statuses, activity_id, booking_id)
       let model = set_page_booking_form(model, BookingClosed)
       let refetch = case model.page {
-        ActivityBookingsPage(id, _, _) if id == activity_id ->
+        ActivityBookingsPage(id, _, _, _) if id == activity_id ->
           fetch_bookings(id)
         _ -> effect.none()
       }
@@ -3842,7 +4014,7 @@ pub fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
       let statuses = replace_status_booking(model.statuses, booking)
       let model = set_page_booking_form(model, BookingClosed)
       let refetch = case model.page {
-        ActivityBookingsPage(id, _, _) if id == activity_id ->
+        ActivityBookingsPage(id, _, _, _) if id == activity_id ->
           fetch_bookings(id)
         _ -> effect.none()
       }
@@ -3875,7 +4047,7 @@ pub fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
     // bookings page — a response for a page we've navigated away from is stale.
     ApiReturnedBookings(id, result) ->
       case model.page {
-        ActivityBookingsPage(page_id, _, booking_form) if page_id == id -> {
+        ActivityBookingsPage(page_id, _, booking_form, _) if page_id == id -> {
           let bookings = case result {
             Ok(bookings) -> Loaded(bookings)
             Error(_) -> Failed(LoadBookingsFailed)
@@ -3883,7 +4055,9 @@ pub fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
           #(
             Model(
               ..model,
-              page: ActivityBookingsPage(id, bookings, booking_form),
+              // A fresh list is the truth about every check-off, so any
+              // stale departure error goes with it.
+              page: ActivityBookingsPage(id, bookings, booking_form, None),
             ),
             effect.none(),
           )
@@ -4358,6 +4532,30 @@ fn cancel_booking(
   )
 }
 
+/// PUT one badbuss departure check-off. Each stage has its own endpoint and
+/// writes only its own column, so two staff ticking the two stages of the same
+/// booking at once cannot overwrite each other. `was` rides along so a failure
+/// can roll the optimistic tick back. The server refuses the write unless the
+/// booking sits on a beach-bus slot.
+fn set_booking_departure(
+  booking_id: Uuid,
+  stage: DepartureStage,
+  checked: Bool,
+  was: Bool,
+) -> Effect(Msg) {
+  rsvp.put(
+    api_prefix
+      <> "/api/bookings/"
+      <> uuid.to_string(booking_id)
+      <> "/"
+      <> departure_stage_path(stage),
+    json.object([#("checked", json.bool(checked))]),
+    rsvp.expect_json(model.booking_decoder(), fn(result) {
+      ApiSetBookingDeparture(booking_id, stage, was, result)
+    }),
+  )
+}
+
 /// POST the restore of a cancelled booking (issue #43). The server re-checks
 /// capacity — the booking occupies spots again.
 fn restore_booking(activity_id: Uuid, booking_id: Uuid) -> Effect(Msg) {
@@ -4765,7 +4963,7 @@ pub fn uri_to_page(
             _ -> fetch_activity(id)
           }
           #(
-            ActivityBookingsPage(id, Loading, BookingClosed),
+            ActivityBookingsPage(id, Loading, BookingClosed, None),
             effect.batch([
               activity_effect,
               fetch_activity_spots(id),
@@ -4834,7 +5032,7 @@ fn view(model: Model) -> Element(Msg) {
         model.scout_groups,
         model.session,
       )
-    ActivityBookingsPage(id, bookings, booking_form) ->
+    ActivityBookingsPage(id, bookings, booking_form, departure_error) ->
       view_activity_bookings(
         model.translator,
         detail_of(model, id),
@@ -4845,6 +5043,7 @@ fn view(model: Model) -> Element(Msg) {
         model.booker,
         model.booking_ui,
         model.scout_groups,
+        departure_error,
       )
     RecurringBookingsPage(kind, selected_day) ->
       view_recurring_bookings(
@@ -7241,6 +7440,9 @@ fn view_time_interval(
 /// activity (title, time, spots filled) above a card per booking. The header
 /// reads from the shared caches via `activity_state`; `bookings` is the
 /// per-route fetch.
+///
+/// On a badbuss slot — and only there — each card also carries the two departure
+/// check-offs; `departure_error` reports a tick that failed to save.
 fn view_activity_bookings(
   translator: Translator,
   activity_state: RemoteData(Activity),
@@ -7251,6 +7453,7 @@ fn view_activity_bookings(
   booker: BookerIdentity,
   booking_ui: BookingUi,
   scout_groups: RemoteData(List(ScoutGroup)),
+  departure_error: Option(AppError),
 ) -> Element(Msg) {
   let t = fn(key) { g18n.translate(translator, key) }
   let max_attendees = case activity_state {
@@ -7260,6 +7463,15 @@ fn view_activity_bookings(
   let loaded_bookings = case bookings {
     Loaded(items) -> items
     _ -> []
+  }
+  // The check-offs are a badbuss thing only: the beach bus staff tick each kår
+  // off as it leaves. Klättervägg and ordinary activities never show them, and
+  // the server refuses the write for anything but a beach-bus slot. Absent while
+  // the activity is still loading, so the boxes can't flash in on a slot that
+  // turns out not to be badbuss.
+  let show_departures = case activity_state {
+    Loaded(activity) -> activity.recurring_kind == Some(BeachBus)
+    NotAsked | Loading | Failed(_) -> False
   }
   html.div([attribute.class("flex flex-col p-3 gap-4")], [
     // The same booking drawer as the detail page, hosting the edit form for
@@ -7290,6 +7502,14 @@ fn view_activity_bookings(
       html.h2([attribute.class("text-body-l font-semibold")], [
         element.text(t("bookings.heading")),
       ]),
+      // A check-off that didn't save. Sits above the list rather than on the
+      // card so it can't be missed, and the rolled-back box shows which tick it
+      // was about.
+      case departure_error {
+        Some(err) ->
+          component.error_banner(t("error.heading"), t(app_error_key(err)))
+        None -> element.none()
+      },
       case bookings {
         NotAsked | Loading ->
           html.div([attribute.class("flex justify-center py-6")], [
@@ -7315,6 +7535,7 @@ fn view_activity_bookings(
                   // matching the server's manage rule.
                   can_manage_bookings,
                   booking_form,
+                  show_departures,
                 ),
               )
             }),
@@ -7597,12 +7818,14 @@ fn view_bookings_header(
 
 /// One booking rendered as a card: the booker group in bold, then the
 /// free-text group (when a scout group name is also present), participant
-/// count, responsible leader, and a tappable phone link.
+/// count, responsible leader, and a tappable phone link. On a badbuss slot
+/// (`show_departures`) the two departure check-offs sit below that.
 fn view_booking_card(
   translator: Translator,
   booking: Booking,
   manageable: Bool,
   booking_form: BookingFormState,
+  show_departures: Bool,
 ) -> Element(Msg) {
   // Prefer the scout group name from the booker's token; fall back to the
   // free-text group, then to a placeholder when neither is present (the
@@ -7707,6 +7930,7 @@ fn view_booking_card(
               ])
             None -> element.none()
           },
+          view_departure_checks(translator, booking, show_departures),
           view_booking_card_actions(
             translator,
             booking,
@@ -7715,6 +7939,47 @@ fn view_booking_card(
           ),
         ]),
       ]),
+    ],
+  )
+}
+
+/// The two badbuss departure check-offs for one kår's booking — left the
+/// campsite, then left the beach — under a small heading so the boxes read as
+/// belonging to this kår rather than to the page.
+///
+/// Rendered only on a badbuss slot (`show`) and only for an active booking: a
+/// cancelled kår is not boarding, so ticking it off would be meaningless. The
+/// two stages are independent, so the beach box is not gated on the campsite one
+/// — staff may need to fix either after the fact.
+fn view_departure_checks(
+  translator: Translator,
+  booking: Booking,
+  show: Bool,
+) -> Element(Msg) {
+  use <- bool.guard(when: !show, return: element.none())
+  use <- bool.guard(
+    when: option.is_some(booking.cancellation),
+    return: element.none(),
+  )
+  let t = fn(key) { g18n.translate(translator, key) }
+  html.div(
+    [attribute.class("flex flex-col gap-1 pt-2 border-t border-gray-200")],
+    [
+      html.p([attribute.class("text-body-sm font-semibold text-gray-700")], [
+        element.text(t("bookings.departures_heading")),
+      ]),
+      component.scout_checkbox(
+        t("bookings.left_campsite"),
+        booking.left_campsite,
+        False,
+        fn(checked) { UserToggledDeparture(booking.id, LeftCampsite, checked) },
+      ),
+      component.scout_checkbox(
+        t("bookings.left_beach"),
+        booking.left_beach,
+        False,
+        fn(checked) { UserToggledDeparture(booking.id, LeftBeach, checked) },
+      ),
     ],
   )
 }

--- a/client/src/component.gleam
+++ b/client/src/component.gleam
@@ -173,6 +173,40 @@ pub fn scout_button_disabled(
   )
 }
 
+/// A labelled `scout-checkbox` whose state is owned by the model.
+///
+/// `checked` goes through the JS *property* rather than the attribute (like
+/// `scout_drawer`'s `open`): the component keeps its own internal checked state
+/// once the user clicks it, and only an explicit property write pushes the
+/// model's value back into it. A presence-based attribute could not — going from
+/// checked back to unchecked would just remove an attribute Lustre never
+/// rendered, leaving the box visually ticked while the model says otherwise.
+///
+/// `disabled` marks a box the viewer may look at but not change.
+pub fn scout_checkbox(
+  label: String,
+  checked: Bool,
+  disabled: Bool,
+  on_check: fn(Bool) -> msg,
+) -> Element(msg) {
+  element.element(
+    "scout-checkbox",
+    [
+      attribute.attribute("label", label),
+      attribute.property("checked", json.bool(checked)),
+      case disabled {
+        True -> attribute.attribute("disabled", "")
+        False -> attribute.none()
+      },
+      event.on("scoutChecked", {
+        use checked <- decode.subfield(["detail", "checked"], decode.bool)
+        decode.success(on_check(checked))
+      }),
+    ],
+    [],
+  )
+}
+
 pub fn scout_loader(text: String) -> Element(msg) {
   element.element(
     "scout-loader",

--- a/client/test/client_test.gleam
+++ b/client/test/client_test.gleam
@@ -71,6 +71,7 @@ fn an_activity(id: Uuid, max: Option(Int)) -> model.Activity {
     cancellation: None,
     booking_opens_at: None,
     booking_opens_at_override: None,
+    recurring_kind: None,
   )
 }
 
@@ -94,6 +95,7 @@ fn a_detail() -> client.ActivityDetail {
     description: model.BilingualString(sv: "Desc", en: "Desc"),
     location: None,
     booking_opens_at_override: None,
+    recurring_kind: None,
   )
 }
 
@@ -111,6 +113,8 @@ fn a_booking(id: Uuid, activity_id: Uuid) -> model.Booking {
     participant_count: 2,
     booked_for_other: False,
     cancellation: None,
+    left_campsite: False,
+    left_beach: False,
   )
 }
 
@@ -805,7 +809,12 @@ pub fn uri_to_page_bookings_for_valid_uuid_test() {
     "/_services/booking/activities/" <> uuid.to_string(id_a()) <> "/bookings"
   let #(page, _) = client.uri_to_page(parse_uri(path), dict.new())
   assert page
-    == client.ActivityBookingsPage(id_a(), client.Loading, client.BookingClosed)
+    == client.ActivityBookingsPage(
+      id_a(),
+      client.Loading,
+      client.BookingClosed,
+      None,
+    )
 }
 
 pub fn uri_to_page_manage_lists_activities_in_manage_mode_test() {
@@ -993,7 +1002,7 @@ pub fn uri_to_page_reads_the_overview_day_from_the_query_test() {
       ),
       dict.new(),
     )
-  assert page == client.RecurringBookingsPage(client.BeachBus, other_day())
+  assert page == client.RecurringBookingsPage(model.BeachBus, other_day())
 }
 
 pub fn overview_day_defaults_to_today_without_a_query_test() {
@@ -1005,7 +1014,7 @@ pub fn overview_day_defaults_to_today_without_a_query_test() {
       dict.new(),
     )
   let assert client.RecurringBookingsPage(kind, _) = page
-  assert kind == client.ClimbingWall
+  assert kind == model.ClimbingWall
 }
 
 pub fn back_to_the_overview_restores_the_day_and_loads_its_slots_test() {
@@ -1013,9 +1022,9 @@ pub fn back_to_the_overview_restores_the_day_and_loads_its_slots_test() {
     "/_services/booking/beach-bus?" <> client.overview_query(other_day())
   let picked = route(base_model(), overview_url)
   assert picked.page
-    == client.RecurringBookingsPage(client.BeachBus, other_day())
+    == client.RecurringBookingsPage(model.BeachBus, other_day())
   // The day's slots load on the route change (the same path a Back takes).
-  assert client.recurring_remote(picked, #(client.BeachBus, other_day()))
+  assert client.recurring_remote(picked, #(model.BeachBus, other_day()))
     == client.Loading
 }
 
@@ -1366,6 +1375,7 @@ pub fn deleting_unheld_booking_leaves_statuses_test() {
         id_a(),
         client.Loaded([mine]),
         client.UnbookSubmitting(id_c()),
+        None,
       ),
       statuses: dict.from_list([#(id_a(), model.Booked([mine]))]),
     )
@@ -1386,13 +1396,15 @@ pub fn updating_unheld_booking_leaves_statuses_test() {
         id_a(),
         client.Loaded([mine, foreign]),
         client.BookingSubmitting(client.BookingEdit(id_c())),
+        None,
       ),
       statuses: dict.from_list([#(id_a(), model.Booked([mine]))]),
     )
   let #(next, _) = client.update(model_, client.ApiUpdatedBooking(Ok(foreign)))
   assert dict.get(next.statuses, id_a()) == Ok(model.Booked([mine]))
   // The drawer closes and the page survives.
-  let assert client.ActivityBookingsPage(_, _, client.BookingClosed) = next.page
+  let assert client.ActivityBookingsPage(_, _, client.BookingClosed, _) =
+    next.page
 }
 
 // UPDATE: bookings-page manage flows (plan 16) ----------------------------------
@@ -1407,12 +1419,17 @@ pub fn edit_booking_card_opens_drawer_on_bookings_page_test() {
         id_a(),
         client.Loaded([booking]),
         client.BookingClosed,
+        None,
       ),
     )
   let #(next, _) =
     client.update(model_, client.UserClickedEditBookingCard(booking))
-  let assert client.ActivityBookingsPage(_, _, client.BookingOpen(_, _, mode)) =
-    next.page
+  let assert client.ActivityBookingsPage(
+    _,
+    _,
+    client.BookingOpen(_, _, mode),
+    _,
+  ) = next.page
   assert mode == client.BookingEdit(id_b())
 }
 
@@ -1426,6 +1443,7 @@ pub fn submitting_edit_on_bookings_page_submits_test() {
         id_a(),
         client.Loaded([booking]),
         client.BookingClosed,
+        None,
       ),
     )
   let #(opened, _) =
@@ -1439,8 +1457,12 @@ pub fn submitting_edit_on_bookings_page_submits_test() {
     )
   let #(next, _) =
     client.update(opened, client.UserSubmittedBookingForm(Ok(fields)))
-  let assert client.ActivityBookingsPage(_, _, client.BookingSubmitting(mode)) =
-    next.page
+  let assert client.ActivityBookingsPage(
+    _,
+    _,
+    client.BookingSubmitting(mode),
+    _,
+  ) = next.page
   assert mode == client.BookingEdit(id_b())
 }
 
@@ -1454,15 +1476,16 @@ pub fn unbook_card_confirms_then_submits_test() {
         id_a(),
         client.Loaded([booking]),
         client.BookingClosed,
+        None,
       ),
     )
   let #(confirming, _) =
     client.update(model_, client.UserClickedUnbookCard(id_b()))
-  let assert client.ActivityBookingsPage(_, _, client.UnbookConfirming(id)) =
+  let assert client.ActivityBookingsPage(_, _, client.UnbookConfirming(id), _) =
     confirming.page
   assert id == id_b()
   let #(next, _) = client.update(confirming, client.UserClickedConfirmUnbook)
-  let assert client.ActivityBookingsPage(_, _, client.UnbookSubmitting(_)) =
+  let assert client.ActivityBookingsPage(_, _, client.UnbookSubmitting(_), _) =
     next.page
 }
 
@@ -1477,12 +1500,17 @@ pub fn edit_self_booking_card_opens_drawer_and_submits_test() {
         id_a(),
         client.Loaded([booking]),
         client.BookingClosed,
+        None,
       ),
     )
   let #(opened, _) =
     client.update(model_, client.UserClickedEditBookingCard(booking))
-  let assert client.ActivityBookingsPage(_, _, client.BookingOpen(_, _, mode)) =
-    opened.page
+  let assert client.ActivityBookingsPage(
+    _,
+    _,
+    client.BookingOpen(_, _, mode),
+    _,
+  ) = opened.page
   assert mode == client.BookingEdit(id_b())
   let fields =
     client.BookingFormFields(
@@ -1493,7 +1521,7 @@ pub fn edit_self_booking_card_opens_drawer_and_submits_test() {
     )
   let #(next, _) =
     client.update(opened, client.UserSubmittedBookingForm(Ok(fields)))
-  let assert client.ActivityBookingsPage(_, _, client.BookingSubmitting(_)) =
+  let assert client.ActivityBookingsPage(_, _, client.BookingSubmitting(_), _) =
     next.page
 }
 
@@ -1507,15 +1535,16 @@ pub fn unbook_self_booking_card_confirms_then_submits_test() {
         id_a(),
         client.Loaded([booking]),
         client.BookingClosed,
+        None,
       ),
     )
   let #(confirming, _) =
     client.update(model_, client.UserClickedUnbookCard(id_b()))
-  let assert client.ActivityBookingsPage(_, _, client.UnbookConfirming(id)) =
+  let assert client.ActivityBookingsPage(_, _, client.UnbookConfirming(id), _) =
     confirming.page
   assert id == id_b()
   let #(next, _) = client.update(confirming, client.UserClickedConfirmUnbook)
-  let assert client.ActivityBookingsPage(_, _, client.UnbookSubmitting(_)) =
+  let assert client.ActivityBookingsPage(_, _, client.UnbookSubmitting(_), _) =
     next.page
 }
 
@@ -1529,6 +1558,7 @@ fn bookings_page_model(booking: model.Booking) -> client.Model {
       id_a(),
       client.Loaded([booking]),
       client.BookingClosed,
+      None,
     ),
   )
 }
@@ -1541,6 +1571,7 @@ pub fn cancel_card_opens_reason_drawer_test() {
     _,
     _,
     client.CancelReasonEditing(id, reason, error),
+    _,
   ) = next.page
   assert id == id_b()
   assert reason == ""
@@ -1559,6 +1590,7 @@ pub fn confirm_cancel_with_empty_reason_is_ignored_test() {
     _,
     _,
     client.CancelReasonEditing(_, _, _),
+    _,
   ) = next.page
 }
 
@@ -1573,6 +1605,7 @@ pub fn cancel_reason_confirm_moves_to_submitting_test() {
     _,
     _,
     client.CancelSubmitting(id, reason),
+    _,
   ) = next.page
   assert id == id_b()
   assert reason == "Dubbelbokning"
@@ -1592,11 +1625,13 @@ pub fn cancelled_booking_replaces_status_and_closes_test() {
         id_a(),
         client.Loaded([a_booking(id_b(), id_a())]),
         client.CancelSubmitting(id_b(), "Dubbelbokning"),
+        None,
       ),
     )
   let #(next, _) =
     client.update(model_, client.ApiCancelledBooking(id_a(), Ok(cancelled)))
-  let assert client.ActivityBookingsPage(_, _, client.BookingClosed) = next.page
+  let assert client.ActivityBookingsPage(_, _, client.BookingClosed, _) =
+    next.page
   let status = client.status_of(next.statuses, id_a())
   assert client.cancelled_bookings_of(status) == [cancelled]
   assert !client.has_active_booking(status)
@@ -1612,6 +1647,7 @@ pub fn failed_cancel_keeps_reason_and_shows_error_test() {
         id_a(),
         client.Loaded([a_booking(id_b(), id_a())]),
         client.CancelSubmitting(id_b(), "Dubbelbokning"),
+        None,
       ),
     )
   let #(next, _) =
@@ -1623,6 +1659,7 @@ pub fn failed_cancel_keeps_reason_and_shows_error_test() {
     _,
     _,
     client.CancelReasonEditing(id, reason, error),
+    _,
   ) = next.page
   assert id == id_b()
   assert reason == "Dubbelbokning"
@@ -1633,11 +1670,11 @@ pub fn restore_card_confirms_then_submits_test() {
   let model_ = bookings_page_model(a_cancelled_booking(id_b(), id_a()))
   let #(confirming, _) =
     client.update(model_, client.UserClickedRestoreBookingCard(id_b()))
-  let assert client.ActivityBookingsPage(_, _, client.RestoreConfirming(id)) =
+  let assert client.ActivityBookingsPage(_, _, client.RestoreConfirming(id), _) =
     confirming.page
   assert id == id_b()
   let #(next, _) = client.update(confirming, client.UserClickedConfirmRestore)
-  let assert client.ActivityBookingsPage(_, _, client.RestoreSubmitting(_)) =
+  let assert client.ActivityBookingsPage(_, _, client.RestoreSubmitting(_), _) =
     next.page
 }
 
@@ -1654,11 +1691,13 @@ pub fn restored_booking_replaces_status_and_closes_test() {
         id_a(),
         client.Loaded([a_cancelled_booking(id_b(), id_a())]),
         client.RestoreSubmitting(id_b()),
+        None,
       ),
     )
   let #(next, _) =
     client.update(model_, client.ApiRestoredBooking(id_a(), Ok(restored)))
-  let assert client.ActivityBookingsPage(_, _, client.BookingClosed) = next.page
+  let assert client.ActivityBookingsPage(_, _, client.BookingClosed, _) =
+    next.page
   let status = client.status_of(next.statuses, id_a())
   assert client.has_active_booking(status)
   assert client.cancelled_bookings_of(status) == []
@@ -1697,6 +1736,169 @@ pub fn cancelled_bookings_are_not_active_test() {
   assert client.self_booking_of(mixed) == Some(a_booking(id_c(), id_a()))
 }
 
+// UPDATE: badbuss departure check-offs -----------------------------------------
+
+/// Ticking a box flips the flag in the list straight away, without waiting for
+/// the server — the checkbox has to follow the finger, and the model has to move
+/// in step with the component's own checked state.
+pub fn toggling_departure_ticks_optimistically_test() {
+  let model_ = bookings_page_model(a_booking(id_b(), id_a()))
+  let #(next, _) =
+    client.update(
+      model_,
+      client.UserToggledDeparture(id_b(), client.LeftCampsite, True),
+    )
+  let assert client.ActivityBookingsPage(_, client.Loaded([booking]), _, error) =
+    next.page
+  assert booking.left_campsite
+  // The other stage is untouched.
+  assert !booking.left_beach
+  assert error == None
+}
+
+/// The two stages are independent: the beach box can be ticked on its own.
+pub fn toggling_left_beach_leaves_campsite_alone_test() {
+  let model_ = bookings_page_model(a_booking(id_b(), id_a()))
+  let #(next, _) =
+    client.update(
+      model_,
+      client.UserToggledDeparture(id_b(), client.LeftBeach, True),
+    )
+  let assert client.ActivityBookingsPage(_, client.Loaded([booking]), _, _) =
+    next.page
+  assert booking.left_beach
+  assert !booking.left_campsite
+}
+
+/// Unticking a set box works the same way round.
+pub fn untoggling_departure_clears_the_flag_test() {
+  let ticked = model.Booking(..a_booking(id_b(), id_a()), left_campsite: True)
+  let #(next, _) =
+    client.update(
+      bookings_page_model(ticked),
+      client.UserToggledDeparture(id_b(), client.LeftCampsite, False),
+    )
+  let assert client.ActivityBookingsPage(_, client.Loaded([booking]), _, _) =
+    next.page
+  assert !booking.left_campsite
+}
+
+/// A toggle for a booking that isn't on the list (a stale card) changes nothing.
+pub fn toggling_departure_for_unknown_booking_is_ignored_test() {
+  let model_ = bookings_page_model(a_booking(id_b(), id_a()))
+  let #(next, _) =
+    client.update(
+      model_,
+      client.UserToggledDeparture(id_c(), client.LeftCampsite, True),
+    )
+  assert next.page == model_.page
+}
+
+/// The check-offs only exist on the bookings page, so a toggle anywhere else is
+/// a no-op.
+pub fn toggling_departure_off_the_bookings_page_is_ignored_test() {
+  let model_ = base_model()
+  let #(next, _) =
+    client.update(
+      model_,
+      client.UserToggledDeparture(id_b(), client.LeftCampsite, True),
+    )
+  assert next.page == model_.page
+}
+
+/// The saved booking replaces the card wholesale, so a tick someone else made on
+/// the *other* stage lands here too.
+pub fn saved_departure_replaces_the_booking_test() {
+  let ticked =
+    model.Booking(
+      ..a_booking(id_b(), id_a()),
+      left_campsite: True,
+      left_beach: True,
+    )
+  let #(next, _) =
+    client.update(
+      bookings_page_model(a_booking(id_b(), id_a())),
+      client.ApiSetBookingDeparture(
+        id_b(),
+        client.LeftCampsite,
+        False,
+        Ok(ticked),
+      ),
+    )
+  let assert client.ActivityBookingsPage(_, client.Loaded([booking]), _, error) =
+    next.page
+  assert booking.left_campsite
+  assert booking.left_beach
+  assert error == None
+}
+
+/// A failed write rolls the tick back to what it was and says so — a box left
+/// claiming a kår has left when nothing was saved would be worse than an error.
+pub fn failed_departure_rolls_back_and_reports_test() {
+  let model_ = bookings_page_model(a_booking(id_b(), id_a()))
+  let #(ticked, _) =
+    client.update(
+      model_,
+      client.UserToggledDeparture(id_b(), client.LeftCampsite, True),
+    )
+  let #(next, _) =
+    client.update(
+      ticked,
+      client.ApiSetBookingDeparture(
+        id_b(),
+        client.LeftCampsite,
+        False,
+        Error(rsvp.BadBody),
+      ),
+    )
+  let assert client.ActivityBookingsPage(_, client.Loaded([booking]), _, error) =
+    next.page
+  assert !booking.left_campsite
+  assert error == Some(client.SetDepartureFailed)
+}
+
+/// Unticking that fails rolls forward — back to ticked, the stored value.
+pub fn failed_untick_restores_the_tick_test() {
+  let ticked = model.Booking(..a_booking(id_b(), id_a()), left_campsite: True)
+  let #(next, _) =
+    client.update(
+      bookings_page_model(model.Booking(..ticked, left_campsite: False)),
+      client.ApiSetBookingDeparture(
+        id_b(),
+        client.LeftCampsite,
+        True,
+        Error(rsvp.BadBody),
+      ),
+    )
+  let assert client.ActivityBookingsPage(_, client.Loaded([booking]), _, error) =
+    next.page
+  assert booking.left_campsite
+  assert error == Some(client.SetDepartureFailed)
+}
+
+/// A fresh list is the truth about every check-off, so it clears a stale error.
+pub fn refetched_bookings_clear_the_departure_error_test() {
+  let model_ = bookings_page_model(a_booking(id_b(), id_a()))
+  let #(failed, _) =
+    client.update(
+      model_,
+      client.ApiSetBookingDeparture(
+        id_b(),
+        client.LeftCampsite,
+        False,
+        Error(rsvp.BadBody),
+      ),
+    )
+  let assert client.ActivityBookingsPage(_, _, _, Some(_)) = failed.page
+  let #(next, _) =
+    client.update(
+      failed,
+      client.ApiReturnedBookings(id_a(), Ok([a_booking(id_b(), id_a())])),
+    )
+  let assert client.ActivityBookingsPage(_, _, _, error) = next.page
+  assert error == None
+}
+
 // UPDATE: bookings list fetch --------------------------------------------------
 
 pub fn returned_bookings_land_on_matching_page_test() {
@@ -1708,6 +1910,7 @@ pub fn returned_bookings_land_on_matching_page_test() {
         id_a(),
         client.Loading,
         client.BookingClosed,
+        None,
       ),
     )
   let #(next, _) =
@@ -1717,6 +1920,7 @@ pub fn returned_bookings_land_on_matching_page_test() {
       id_a(),
       client.Loaded([booking]),
       client.BookingClosed,
+      None,
     )
 }
 
@@ -1731,12 +1935,18 @@ pub fn returned_bookings_dropped_for_other_activity_test() {
         id_a(),
         client.Loading,
         client.BookingClosed,
+        None,
       ),
     )
   let #(next, _) =
     client.update(model_, client.ApiReturnedBookings(id_b(), Ok([booking])))
   assert next.page
-    == client.ActivityBookingsPage(id_a(), client.Loading, client.BookingClosed)
+    == client.ActivityBookingsPage(
+      id_a(),
+      client.Loading,
+      client.BookingClosed,
+      None,
+    )
 }
 
 pub fn failed_bookings_fetch_marks_failed_test() {
@@ -1747,6 +1957,7 @@ pub fn failed_bookings_fetch_marks_failed_test() {
         id_a(),
         client.Loading,
         client.BookingClosed,
+        None,
       ),
     )
   let #(next, _) =
@@ -1759,6 +1970,7 @@ pub fn failed_bookings_fetch_marks_failed_test() {
       id_a(),
       client.Failed(client.LoadBookingsFailed),
       client.BookingClosed,
+      None,
     )
 }
 

--- a/docs/plans/28-badbuss-departure-checkmarks.md
+++ b/docs/plans/28-badbuss-departure-checkmarks.md
@@ -1,0 +1,119 @@
+# 28. Badbuss departure check-offs per kår
+
+> **Status: 🚧 In progress** (as of 2026-07-29)
+
+## Why
+
+The badbuss staff need to account for every kår twice per slot: once when the
+kår has left the campsite, and again when it has left the beach. Today the
+slot's bookings view lists each kår but offers nowhere to record that, so the
+tally is kept on paper.
+
+Two checkmarks per group on the slot's bookings view, **badbuss only** —
+klättervägg and ordinary activities must look exactly as they do now.
+
+## Shape
+
+The check-offs hang off the **booking** (one booking = one kår on one slot), so
+they are two new columns on `booking` rather than a new table: there is exactly
+one row per kår per slot already, and the flags have no history to keep.
+
+### Database
+
+`server/priv/migrations/20260729075614-booking_beach_bus_departures.sql`:
+
+```sql
+ALTER TABLE booking ADD COLUMN left_campsite BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE booking ADD COLUMN left_beach BOOLEAN NOT NULL DEFAULT FALSE;
+```
+
+Chosen to be safe for the live bookings: both columns are new, and `NOT NULL`
+with a *constant* default is a catalog-only change in PostgreSQL 11+ — no table
+rewrite, no row is read or moved, and every existing booking keeps all of its
+current values. `migration:down` drops the two columns and nothing else.
+
+Booleans rather than `TIMESTAMPTZ`: the ask is a checkmark, and "has this kår
+left?" is the whole truth being recorded. Should staff later want *when*, that
+is a follow-up migration, not a reason to store a timestamp nobody displays.
+
+### API
+
+Two endpoints, one per stage:
+
+| Method | Path | Body |
+| ------ | ---- | ---- |
+| PUT | `/api/bookings/:id/left-campsite` | `{"checked": true｜false}` |
+| PUT | `/api/bookings/:id/left-beach` | `{"checked": true｜false}` |
+
+Both answer `200` with the whole updated booking.
+
+- **One column per write.** Deliberately *not* one endpoint taking both flags:
+  two staff members at the bus, each with a phone holding a slightly stale list,
+  would otherwise clobber each other — the second write would carry a stale
+  value for the first's flag. Each endpoint writes only its own column, so both
+  ticks survive regardless of order.
+- **Idempotent**, so a mistaken tick is undone by sending `false`.
+- **Badbuss only.** The handler loads the booking's activity and refuses with
+  `409 Booking is not on a beach bus slot` unless
+  `recurring_activity_kind = 'beach-bus'`. A cancelled booking is refused too
+  (`409 Booking is cancelled`) — that kår is not boarding. Both facts are
+  stable (a booking never moves activity, an activity never changes kind), so
+  the check needs no transaction around it.
+- **Roles:** `bookings:read`, `activities:manage` or `bookings:others:create`
+  (`admin` implies all three) — the same set that may *read* the badbuss
+  booking lists, since whoever runs the bus is who ticks the boxes. Notably
+  *not* the booker, who cannot read the slot's list at all.
+
+`Booking` JSON gains `left_campsite` / `left_beach` (always present; always
+`false` on a non-badbuss booking). Both decode with a `False` default, so a
+payload predating the columns still decodes.
+
+### Telling badbuss apart, client-side
+
+The bookings view had no way to know which kind of activity it was showing:
+`recurring_activity_kind` existed only inside the server. So:
+
+- `RecurringKind` (`BeachBus` | `ClimbingWall`) moves into `shared/model`, and
+  the client's and `web/activities.gleam`'s private duplicates are deleted in
+  favour of it.
+- `Activity` gains `recurring_kind: Option(RecurringKind)`, encoded by
+  `activity.to_json` and carried on the client's `ActivityDetail`.
+  **Detail-only** — `summary_to_json` and `ActivitySummary` deliberately do not
+  carry it, so no list payload or ETag changes.
+- The four activity create/update queries now return
+  `recurring_activity_kind` as well, so editing a badbuss slot can't hand back
+  a row claiming it has no kind.
+
+### Client
+
+`view_booking_card` renders the two `scout-checkbox`es under a small
+"Avfärd" heading when — and only when — `activity.recurring_kind ==
+Some(BeachBus)` and the booking is active. New `component.scout_checkbox` binds
+`checked` through the JS **property**, not a presence attribute: the component
+owns its checked state after a click, and only a property write pushes the
+model's value back in.
+
+Ticking is **optimistic** — a checkbox that waits for the network reads as
+broken, and the model has to move in step with the component's own state. The
+response replaces the card wholesale (so a tick someone else made on the other
+stage lands too); a failure rolls the tick back to the value it had and shows
+`error.set_departure` above the list. `ActivityBookingsPage` gained a
+`departure_error: Option(AppError)` field for that, cleared by the next
+successful tick or list refetch.
+
+## Verification
+
+- `gleam test` in all three packages (`shared` 19, `server` 72, `client` 155).
+- New coverage: recurring-kind round trip and the tolerant decoders
+  (`shared`), the endpoint's auth/role/id/body/method guards (`server`), and
+  the optimistic tick, per-stage independence, replace-on-success,
+  rollback-on-failure and clear-on-refetch flows (`client`).
+- Live against the running app with a seeded database: tick both stages on a
+  badbuss booking, confirm the columns, and confirm the `409` for a booking on
+  an ordinary activity.
+
+## Follow-ups (not in scope)
+
+- A per-slot progress figure ("12 / 18 kårer avfärdade") on the badbuss
+  overview cards. The overview query would need to aggregate the two flags.
+- Recording *when* each stage was ticked, and by whom.

--- a/docs/plans/CLAUDE.md
+++ b/docs/plans/CLAUDE.md
@@ -53,3 +53,4 @@ When you create, finish, or touch a plan here, keep the folder consistent:
 | 25 | [Filter the activity list by location](25-filter-activities-by-location.md) | ✅ Done 2026-07-26 |
 | 26 | [Activity-list filters live in the URL (Back restores them)](26-filters-in-the-url.md) | ✅ Done 2026-07-26 |
 | 27 | [Location filter offers only locations that have an activity](27-location-filter-only-locations-with-activities.md) | 🚧 In progress |
+| 28 | [Badbuss departure check-offs per kår](28-badbuss-departure-checkmarks.md) | 🚧 In progress |

--- a/server/priv/migrations/20260729075614-booking_beach_bus_departures.sql
+++ b/server/priv/migrations/20260729075614-booking_beach_bus_departures.sql
@@ -1,0 +1,18 @@
+--- migration:up
+-- Badbuss departure check-offs: the two boarding stages the beach-bus staff
+-- tick off per booking (per kår) on a slot — left the campsite, then left the
+-- beach. Only meaningful for bookings on a slot whose
+-- activity.recurring_activity_kind = 'beach-bus'; the columns exist on every
+-- booking because they hang off the booking, and the API refuses to set them
+-- for any other kind of activity.
+--
+-- Deliberately additive and non-destructive: both columns are new, NOT NULL
+-- with a constant FALSE default, so PostgreSQL fills them in from the catalog
+-- without rewriting the table and every existing booking keeps all of its
+-- current values (nothing is read, moved, or re-typed).
+ALTER TABLE booking ADD COLUMN left_campsite BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE booking ADD COLUMN left_beach BOOLEAN NOT NULL DEFAULT FALSE;
+--- migration:down
+ALTER TABLE booking DROP COLUMN left_campsite;
+ALTER TABLE booking DROP COLUMN left_beach;
+--- migration:end

--- a/server/priv/openapi.yaml
+++ b/server/priv/openapi.yaml
@@ -725,6 +725,8 @@ paths:
                         participant_count: 12
                         booked_for_other: false
                         cancellation: null
+                        left_campsite: false
+                        left_beach: false
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -796,6 +798,8 @@ paths:
                 participant_count: 12
                 booked_for_other: false
                 cancellation: null
+                left_campsite: false
+                left_beach: false
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -896,6 +900,8 @@ paths:
                 participant_count: 12
                 booked_for_other: false
                 cancellation: null
+                left_campsite: false
+                left_beach: false
         '400':
           $ref: '#/components/responses/BadRequest'
         '404':
@@ -959,6 +965,8 @@ paths:
                 participant_count: 15
                 booked_for_other: false
                 cancellation: null
+                left_campsite: false
+                left_beach: false
         '400':
           $ref: '#/components/responses/BadRequest'
         '404':
@@ -1079,6 +1087,8 @@ paths:
                 participant_count: 12
                 booked_for_other: false
                 cancellation: "Dubbelbokning — kåren har redan en tid"
+                left_campsite: false
+                left_beach: false
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -1144,6 +1154,8 @@ paths:
                 participant_count: 12
                 booked_for_other: false
                 cancellation: null
+                left_campsite: false
+                left_beach: false
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':
@@ -1181,6 +1193,88 @@ paths:
                           - "Booking is not cancelled"
               example:
                 error: "Booking is not cancelled"
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /bookings/{id}/left-campsite:
+    put:
+      tags:
+        - Bookings
+      summary: Tick the badbuss "left the campsite" check-off
+      description: |
+        Set (or clear) the badbuss departure check-off recording that this
+        booking's kår has left the campsite. The beach-bus staff tick each kår
+        off from the slot's bookings view.
+
+        **Badbuss only.** The request is refused with a 409 unless the booking's
+        activity is a slot of the `beach-bus` recurring kind, and also when the
+        booking is cancelled — that kår is not boarding.
+
+        Open to everyone who may read the badbuss booking lists
+        (`bookings:read`, `activities:manage` or `bookings:others:create`;
+        `admin` implies all three): whoever runs the bus is who ticks the boxes.
+
+        Idempotent, and writes only its own column — the sibling
+        `left-beach` flag is never touched, so two staff members ticking the two
+        stages of the same booking at the same time cannot overwrite each other.
+      operationId: setBookingLeftCampsite
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+      parameters:
+        - $ref: '#/components/parameters/BookingId'
+      requestBody:
+        $ref: '#/components/requestBodies/DepartureCheck'
+      responses:
+        '200':
+          $ref: '#/components/responses/DepartureUpdated'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/NotABeachBusBooking'
+        '500':
+          $ref: '#/components/responses/ServerError'
+
+  /bookings/{id}/left-beach:
+    put:
+      tags:
+        - Bookings
+      summary: Tick the badbuss "left the beach" check-off
+      description: |
+        Set (or clear) the badbuss departure check-off recording that this
+        booking's kår has left the beach (the return leg). The sibling of
+        `PUT /bookings/{id}/left-campsite` — same roles, same badbuss-only and
+        not-cancelled rules, and likewise writes only its own column.
+
+        The two stages are independent: ticking this one does not require
+        `left_campsite`, so staff can correct either in any order.
+      operationId: setBookingLeftBeach
+      security:
+        - bearerAuth: []
+        - cookieAuth: []
+      parameters:
+        - $ref: '#/components/parameters/BookingId'
+      requestBody:
+        $ref: '#/components/requestBodies/DepartureCheck'
+      responses:
+        '200':
+          $ref: '#/components/responses/DepartureUpdated'
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '403':
+          $ref: '#/components/responses/Forbidden'
+        '404':
+          $ref: '#/components/responses/NotFound'
+        '409':
+          $ref: '#/components/responses/NotABeachBusBooking'
         '500':
           $ref: '#/components/responses/ServerError'
 
@@ -1457,6 +1551,8 @@ paths:
                             participant_count: 5
                             booked_for_other: false
                             cancellation: null
+                            left_campsite: false
+                            left_beach: false
                       - activity_id: "b4219a53-4746-4a09-8b4e-3e2ac0c3df11"
                         status: "favourited"
         '401':
@@ -2106,6 +2202,17 @@ components:
           nullable: true
           description: The per-activity opens-at override as stored, or null when the activity follows the global default. Edit forms must round-trip this value — not `booking_opens_at` — or they would freeze the global default into an override.
           example: 1748764800
+        recurring_kind:
+          type: string
+          nullable: true
+          enum: ["beach-bus", "climbing-wall", null]
+          description: >-
+            The recurring kind this activity is one slot of — badbuss
+            (`beach-bus`) or klättervägg (`climbing-wall`) — or null for an
+            ordinary activity. Detail-only: `ActivitySummary` omits it. A
+            `beach-bus` slot is what unlocks the departure check-offs on its
+            bookings (`left_campsite` / `left_beach`).
+          example: null
 
     ActivitySummary:
       type: object
@@ -2275,6 +2382,8 @@ components:
         - participant_count
         - booked_for_other
         - cancellation
+        - left_campsite
+        - left_beach
       properties:
         id:
           type: string
@@ -2343,6 +2452,21 @@ components:
             edited or cancelled again, and blocks its user from booking the
             activity again until it is restored or deleted.
           example: null
+        left_campsite:
+          type: boolean
+          description: >-
+            Badbuss departure check-off: the kår has left the campsite. Written
+            by `PUT /bookings/{id}/left-campsite`, which refuses any booking that
+            is not on a `beach-bus` slot — so this is always `false` on an
+            ordinary booking.
+          example: false
+        left_beach:
+          type: boolean
+          description: >-
+            Badbuss departure check-off: the kår has left the beach (the return
+            leg). Written by `PUT /bookings/{id}/left-beach`. Independent of
+            `left_campsite`.
+          example: false
 
     GroupCount:
       type: object
@@ -3041,3 +3165,64 @@ components:
 
     Forbidden:
       description: Forbidden - the authenticated user lacks the required role
+
+    DepartureUpdated:
+      description: >-
+        Check-off saved; returns the whole booking, so the response also carries
+        the other stage as currently stored.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Booking'
+          example:
+            id: "dd000001-0000-4000-8000-000000000001"
+            user_id: "a1b2c3d4-e5f6-4a90-abcd-ef1234567890"
+            activity_id: "6f5e1d46-5f58-4e23-9a9d-8c2bfc2d22a0"
+            booker_name: "Anna Svensson"
+            booker_group_id: 101
+            booker_group_name: "Sjöscoutkåren Dansen"
+            group_free_text: "Patrull Örnarna"
+            responsible_name: "Anna Svensson"
+            phone_number: "+46701234567"
+            participant_count: 12
+            booked_for_other: false
+            cancellation: null
+            left_campsite: true
+            left_beach: false
+
+    NotABeachBusBooking:
+      description: >-
+        The booking is not on a `beach-bus` slot, so it has no departure
+        check-offs — or it is cancelled, so it is not boarding.
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [error]
+            properties:
+              error:
+                type: string
+                enum:
+                  - "Booking is not on a beach bus slot"
+                  - "Booking is cancelled"
+          example:
+            error: "Booking is not on a beach bus slot"
+
+  requestBodies:
+    DepartureCheck:
+      description: >-
+        The new state of the check-off. Sending the value it already has is a
+        no-op success, so a mistaken tick is undone by sending `false`.
+      required: true
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [checked]
+            properties:
+              checked:
+                type: boolean
+                description: Whether this departure stage is ticked off.
+                example: true
+          example:
+            checked: true

--- a/server/src/server/model/activity.gleam
+++ b/server/src/server/model/activity.gleam
@@ -122,6 +122,16 @@ pub fn group_target_groups_by_activity(
   })
 }
 
+/// The activity's recurring kind, read from the nullable
+/// `recurring_activity_kind` column. `None` for an ordinary activity — and also
+/// for a value this build doesn't recognise, so an unknown kind degrades to
+/// "just an activity" instead of failing the whole response.
+fn parse_recurring_kind(raw: Option(String)) -> Option(model.RecurringKind) {
+  option.then(raw, fn(value) {
+    model.recurring_kind_from_string(value) |> option.from_result
+  })
+}
+
 // --- activity row -> Activity ----------------------------------------------
 
 pub fn from_create_activity_with_max_attendees_row(
@@ -145,6 +155,7 @@ pub fn from_create_activity_with_max_attendees_row(
     cancellation: embed_cancellation(embeds, row.id),
     booking_opens_at: option.or(row.booking_opens_at, default_booking_opens_at),
     booking_opens_at_override: row.booking_opens_at,
+    recurring_kind: parse_recurring_kind(row.recurring_activity_kind),
   )
 }
 
@@ -169,6 +180,7 @@ pub fn from_create_activity_without_max_attendees_row(
     cancellation: embed_cancellation(embeds, row.id),
     booking_opens_at: option.or(row.booking_opens_at, default_booking_opens_at),
     booking_opens_at_override: row.booking_opens_at,
+    recurring_kind: parse_recurring_kind(row.recurring_activity_kind),
   )
 }
 
@@ -193,6 +205,7 @@ pub fn from_search_activity_row(
     cancellation: embed_cancellation(embeds, row.id),
     booking_opens_at: option.or(row.booking_opens_at, default_booking_opens_at),
     booking_opens_at_override: row.booking_opens_at,
+    recurring_kind: parse_recurring_kind(row.recurring_activity_kind),
   )
 }
 
@@ -217,6 +230,7 @@ pub fn from_get_activity_row(
     cancellation: embed_cancellation(embeds, row.id),
     booking_opens_at: option.or(row.booking_opens_at, default_booking_opens_at),
     booking_opens_at_override: row.booking_opens_at,
+    recurring_kind: parse_recurring_kind(row.recurring_activity_kind),
   )
 }
 
@@ -241,6 +255,7 @@ pub fn from_get_activities_by_title_row(
     cancellation: embed_cancellation(embeds, row.id),
     booking_opens_at: option.or(row.booking_opens_at, default_booking_opens_at),
     booking_opens_at_override: row.booking_opens_at,
+    recurring_kind: parse_recurring_kind(row.recurring_activity_kind),
   )
 }
 
@@ -265,6 +280,7 @@ pub fn from_get_activities_by_start_time_row(
     cancellation: embed_cancellation(embeds, row.id),
     booking_opens_at: option.or(row.booking_opens_at, default_booking_opens_at),
     booking_opens_at_override: row.booking_opens_at,
+    recurring_kind: parse_recurring_kind(row.recurring_activity_kind),
   )
 }
 
@@ -289,6 +305,7 @@ pub fn from_list_activities_by_title_row(
     cancellation: embed_cancellation(embeds, row.id),
     booking_opens_at: option.or(row.booking_opens_at, default_booking_opens_at),
     booking_opens_at_override: row.booking_opens_at,
+    recurring_kind: parse_recurring_kind(row.recurring_activity_kind),
   )
 }
 
@@ -313,6 +330,7 @@ pub fn from_list_activities_by_start_time_row(
     cancellation: embed_cancellation(embeds, row.id),
     booking_opens_at: option.or(row.booking_opens_at, default_booking_opens_at),
     booking_opens_at_override: row.booking_opens_at,
+    recurring_kind: parse_recurring_kind(row.recurring_activity_kind),
   )
 }
 
@@ -337,6 +355,7 @@ pub fn from_list_beach_bus_activities_row(
     cancellation: embed_cancellation(embeds, row.id),
     booking_opens_at: option.or(row.booking_opens_at, default_booking_opens_at),
     booking_opens_at_override: row.booking_opens_at,
+    recurring_kind: parse_recurring_kind(row.recurring_activity_kind),
   )
 }
 
@@ -361,6 +380,7 @@ pub fn from_list_climbing_wall_activities_row(
     cancellation: embed_cancellation(embeds, row.id),
     booking_opens_at: option.or(row.booking_opens_at, default_booking_opens_at),
     booking_opens_at_override: row.booking_opens_at,
+    recurring_kind: parse_recurring_kind(row.recurring_activity_kind),
   )
 }
 
@@ -385,6 +405,7 @@ pub fn from_list_favourited_activities_row(
     cancellation: embed_cancellation(embeds, row.id),
     booking_opens_at: option.or(row.booking_opens_at, default_booking_opens_at),
     booking_opens_at_override: row.booking_opens_at,
+    recurring_kind: parse_recurring_kind(row.recurring_activity_kind),
   )
 }
 
@@ -409,6 +430,7 @@ pub fn from_update_activity_with_max_attendees_row(
     cancellation: embed_cancellation(embeds, row.id),
     booking_opens_at: option.or(row.booking_opens_at, default_booking_opens_at),
     booking_opens_at_override: row.booking_opens_at,
+    recurring_kind: parse_recurring_kind(row.recurring_activity_kind),
   )
 }
 
@@ -433,6 +455,7 @@ pub fn from_update_activity_without_max_attendees_row(
     cancellation: embed_cancellation(embeds, row.id),
     booking_opens_at: option.or(row.booking_opens_at, default_booking_opens_at),
     booking_opens_at_override: row.booking_opens_at,
+    recurring_kind: parse_recurring_kind(row.recurring_activity_kind),
   )
 }
 
@@ -488,6 +511,7 @@ pub fn to_json(activity: Activity) -> Json {
     cancellation:,
     booking_opens_at:,
     booking_opens_at_override:,
+    recurring_kind:,
   ) = activity
   json.object([
     #("id", id |> uuid.to_string |> json.string),
@@ -508,6 +532,13 @@ pub fn to_json(activity: Activity) -> Json {
       "booking_opens_at_override",
       json.nullable(booking_opens_at_override, unix_seconds_to_json),
     ),
+    // Detail-only (absent from `summary_to_json`): tells the bookings view that
+    // this activity is a badbuss slot, which is what unlocks the departure
+    // check-offs there.
+    #(
+      "recurring_kind",
+      json.nullable(recurring_kind, model.recurring_kind_to_json),
+    ),
   ])
 }
 
@@ -527,6 +558,7 @@ pub fn summary_to_json(activity: Activity) -> Json {
     cancellation:,
     booking_opens_at:,
     booking_opens_at_override: _,
+    recurring_kind: _,
   ) = activity
   json.object([
     #("id", id |> uuid.to_string |> json.string),

--- a/server/src/server/model/booking.gleam
+++ b/server/src/server/model/booking.gleam
@@ -38,6 +38,10 @@ pub fn from_create_booking_with_group_row(
     booked_for_other: row.booked_for_other,
     // A freshly created booking is always active.
     cancellation: None,
+    // …and has been ticked off nowhere yet, so the columns keep their FALSE
+    // defaults rather than the insert having to return them.
+    left_campsite: False,
+    left_beach: False,
   )
 }
 
@@ -60,6 +64,9 @@ pub fn from_create_booking_without_group_row(
     booked_for_other: False,
     // A freshly created booking is always active.
     cancellation: None,
+    // …and has been ticked off nowhere yet (see the with-group variant).
+    left_campsite: False,
+    left_beach: False,
   )
 }
 
@@ -80,6 +87,8 @@ pub fn from_get_booking_row(row: sql.GetBookingRow) -> Booking {
     participant_count: row.participant_count,
     booked_for_other: row.booked_for_other,
     cancellation: row.cancellation_reason,
+    left_campsite: row.left_campsite,
+    left_beach: row.left_beach,
   )
 }
 
@@ -102,6 +111,8 @@ pub fn from_get_bookings_by_activity_row(
     participant_count: row.participant_count,
     booked_for_other: row.booked_for_other,
     cancellation: row.cancellation_reason,
+    left_campsite: row.left_campsite,
+    left_beach: row.left_beach,
   )
 }
 
@@ -122,6 +133,8 @@ pub fn from_get_bookings_by_user_row(row: sql.GetBookingsByUserRow) -> Booking {
     participant_count: row.participant_count,
     booked_for_other: row.booked_for_other,
     cancellation: row.cancellation_reason,
+    left_campsite: row.left_campsite,
+    left_beach: row.left_beach,
   )
 }
 
@@ -142,6 +155,8 @@ pub fn from_update_booking_row(row: sql.UpdateBookingRow) -> Booking {
     participant_count: row.participant_count,
     booked_for_other: row.booked_for_other,
     cancellation: row.cancellation_reason,
+    left_campsite: row.left_campsite,
+    left_beach: row.left_beach,
   )
 }
 
@@ -162,6 +177,8 @@ pub fn from_cancel_booking_row(row: sql.CancelBookingRow) -> Booking {
     participant_count: row.participant_count,
     booked_for_other: row.booked_for_other,
     cancellation: row.cancellation_reason,
+    left_campsite: row.left_campsite,
+    left_beach: row.left_beach,
   )
 }
 
@@ -182,6 +199,56 @@ pub fn from_restore_booking_row(row: sql.RestoreBookingRow) -> Booking {
     participant_count: row.participant_count,
     booked_for_other: row.booked_for_other,
     cancellation: row.cancellation_reason,
+    left_campsite: row.left_campsite,
+    left_beach: row.left_beach,
+  )
+}
+
+pub fn from_set_booking_left_campsite_row(
+  row: sql.SetBookingLeftCampsiteRow,
+) -> Booking {
+  Booking(
+    id: row.id,
+    user_id: row.user_id,
+    activity_id: row.activity_id,
+    booker_name: row.booker_name,
+    booker_group_id: row.booker_group_id,
+    booker_group_name: booker_group_name(
+      row.booker_group_id,
+      row.booker_group_name,
+    ),
+    group_free_text: row.group_free_text,
+    responsible_name: row.responsible_name,
+    phone_number: row.phone_number,
+    participant_count: row.participant_count,
+    booked_for_other: row.booked_for_other,
+    cancellation: row.cancellation_reason,
+    left_campsite: row.left_campsite,
+    left_beach: row.left_beach,
+  )
+}
+
+pub fn from_set_booking_left_beach_row(
+  row: sql.SetBookingLeftBeachRow,
+) -> Booking {
+  Booking(
+    id: row.id,
+    user_id: row.user_id,
+    activity_id: row.activity_id,
+    booker_name: row.booker_name,
+    booker_group_id: row.booker_group_id,
+    booker_group_name: booker_group_name(
+      row.booker_group_id,
+      row.booker_group_name,
+    ),
+    group_free_text: row.group_free_text,
+    responsible_name: row.responsible_name,
+    phone_number: row.phone_number,
+    participant_count: row.participant_count,
+    booked_for_other: row.booked_for_other,
+    cancellation: row.cancellation_reason,
+    left_campsite: row.left_campsite,
+    left_beach: row.left_beach,
   )
 }
 
@@ -241,6 +308,8 @@ pub fn to_json(booking: Booking) -> Json {
     participant_count:,
     booked_for_other:,
     cancellation:,
+    left_campsite:,
+    left_beach:,
   ) = booking
   json.object([
     #("id", id |> uuid.to_string |> json.string),
@@ -255,5 +324,10 @@ pub fn to_json(booking: Booking) -> Json {
     #("participant_count", json.int(participant_count)),
     #("booked_for_other", json.bool(booked_for_other)),
     #("cancellation", json.nullable(cancellation, json.string)),
+    // The badbuss departure check-offs. Sent on every booking (they are plain
+    // columns); only a booking on a beach-bus slot can have them set, and only
+    // that slot's bookings view shows them.
+    #("left_campsite", json.bool(left_campsite)),
+    #("left_beach", json.bool(left_beach)),
   ])
 }

--- a/server/src/server/router.gleam
+++ b/server/src/server/router.gleam
@@ -87,6 +87,13 @@ fn handle_api_request(
     _, ["bookings", _, "cancel"] -> wisp.method_not_allowed([Post])
     Post, ["bookings", id, "restore"] -> booking.restore(req, id, ctx)
     _, ["bookings", _, "restore"] -> wisp.method_not_allowed([Post])
+    // The two badbuss departure check-offs. Badbuss-only: the handler refuses a
+    // booking whose activity is not a beach-bus slot.
+    Put, ["bookings", id, "left-campsite"] ->
+      booking.set_left_campsite(req, id, ctx)
+    _, ["bookings", _, "left-campsite"] -> wisp.method_not_allowed([Put])
+    Put, ["bookings", id, "left-beach"] -> booking.set_left_beach(req, id, ctx)
+    _, ["bookings", _, "left-beach"] -> wisp.method_not_allowed([Put])
     Get, ["locations"] -> location.get_all(req, ctx)
     Post, ["locations"] -> location.create(req, ctx)
     _, ["locations"] -> wisp.method_not_allowed([Get, Post])

--- a/server/src/server/sql.gleam
+++ b/server/src/server/sql.gleam
@@ -31,6 +31,8 @@ pub type CancelBookingRow {
     participant_count: Int,
     booked_for_other: Bool,
     cancellation_reason: Option(String),
+    left_campsite: Bool,
+    left_beach: Bool,
   )
 }
 
@@ -61,6 +63,8 @@ pub fn cancel_booking(
     use participant_count <- decode.field(9, decode.int)
     use booked_for_other <- decode.field(10, decode.bool)
     use cancellation_reason <- decode.field(11, decode.optional(decode.string))
+    use left_campsite <- decode.field(12, decode.bool)
+    use left_beach <- decode.field(13, decode.bool)
     decode.success(CancelBookingRow(
       id:,
       user_id:,
@@ -74,6 +78,8 @@ pub fn cancel_booking(
       participant_count:,
       booked_for_other:,
       cancellation_reason:,
+      left_campsite:,
+      left_beach:,
     ))
   }
 
@@ -96,7 +102,9 @@ WITH cancelled AS (
         phone_number,
         participant_count,
         booked_for_other,
-        cancellation_reason
+        cancellation_reason,
+        left_campsite,
+        left_beach
 )
 SELECT c.id,
     c.user_id,
@@ -109,7 +117,9 @@ SELECT c.id,
     c.phone_number,
     c.participant_count,
     c.booked_for_other,
-    c.cancellation_reason
+    c.cancellation_reason,
+    c.left_campsite,
+    c.left_beach
 FROM cancelled c
     LEFT JOIN scout_group sg ON sg.id = c.booker_group_id
 "
@@ -288,6 +298,7 @@ pub type CreateActivityWithMaxAttendeesRow {
     end_time: Timestamp,
     location_id: Option(Uuid),
     booking_opens_at: Option(Timestamp),
+    recurring_activity_kind: Option(String),
   )
 }
 
@@ -322,6 +333,10 @@ pub fn create_activity_with_max_attendees(
       9,
       decode.optional(pog.timestamp_decoder()),
     )
+    use recurring_activity_kind <- decode.field(
+      10,
+      decode.optional(decode.string),
+    )
     decode.success(CreateActivityWithMaxAttendeesRow(
       id:,
       title:,
@@ -333,6 +348,7 @@ pub fn create_activity_with_max_attendees(
       end_time:,
       location_id:,
       booking_opens_at:,
+      recurring_activity_kind:,
     ))
   }
 
@@ -356,7 +372,9 @@ RETURNING id,
     start_time,
     end_time,
     location_id,
-    booking_opens_at"
+    booking_opens_at,
+    recurring_activity_kind
+"
   |> pog.query
   |> pog.parameter(pog.text(uuid.to_string(arg_1)))
   |> pog.parameter(pog.text(arg_2))
@@ -387,6 +405,7 @@ pub type CreateActivityWithoutMaxAttendeesRow {
     end_time: Timestamp,
     location_id: Option(Uuid),
     booking_opens_at: Option(Timestamp),
+    recurring_activity_kind: Option(String),
   )
 }
 
@@ -419,6 +438,10 @@ pub fn create_activity_without_max_attendees(
       8,
       decode.optional(pog.timestamp_decoder()),
     )
+    use recurring_activity_kind <- decode.field(
+      9,
+      decode.optional(decode.string),
+    )
     decode.success(CreateActivityWithoutMaxAttendeesRow(
       id:,
       title:,
@@ -429,6 +452,7 @@ pub fn create_activity_without_max_attendees(
       end_time:,
       location_id:,
       booking_opens_at:,
+      recurring_activity_kind:,
     ))
   }
 
@@ -451,7 +475,9 @@ RETURNING id,
     start_time,
     end_time,
     location_id,
-    booking_opens_at"
+    booking_opens_at,
+    recurring_activity_kind
+"
   |> pog.query
   |> pog.parameter(pog.text(uuid.to_string(arg_1)))
   |> pog.parameter(pog.text(arg_2))
@@ -1715,6 +1741,8 @@ pub type GetBookingRow {
     participant_count: Int,
     booked_for_other: Bool,
     cancellation_reason: Option(String),
+    left_campsite: Bool,
+    left_beach: Bool,
   )
 }
 
@@ -1743,6 +1771,8 @@ pub fn get_booking(
     use participant_count <- decode.field(9, decode.int)
     use booked_for_other <- decode.field(10, decode.bool)
     use cancellation_reason <- decode.field(11, decode.optional(decode.string))
+    use left_campsite <- decode.field(12, decode.bool)
+    use left_beach <- decode.field(13, decode.bool)
     decode.success(GetBookingRow(
       id:,
       user_id:,
@@ -1756,6 +1786,8 @@ pub fn get_booking(
       participant_count:,
       booked_for_other:,
       cancellation_reason:,
+      left_campsite:,
+      left_beach:,
     ))
   }
 
@@ -1774,7 +1806,9 @@ SELECT b.id,
     b.phone_number,
     b.participant_count,
     b.booked_for_other,
-    b.cancellation_reason
+    b.cancellation_reason,
+    b.left_campsite,
+    b.left_beach
 FROM booking b
     LEFT JOIN scout_group sg ON sg.id = b.booker_group_id
 WHERE b.id = $1
@@ -1844,6 +1878,8 @@ pub type GetBookingsByActivityRow {
     participant_count: Int,
     booked_for_other: Bool,
     cancellation_reason: Option(String),
+    left_campsite: Bool,
+    left_beach: Bool,
   )
 }
 
@@ -1874,6 +1910,8 @@ pub fn get_bookings_by_activity(
     use participant_count <- decode.field(9, decode.int)
     use booked_for_other <- decode.field(10, decode.bool)
     use cancellation_reason <- decode.field(11, decode.optional(decode.string))
+    use left_campsite <- decode.field(12, decode.bool)
+    use left_beach <- decode.field(13, decode.bool)
     decode.success(GetBookingsByActivityRow(
       id:,
       user_id:,
@@ -1887,6 +1925,8 @@ pub fn get_bookings_by_activity(
       participant_count:,
       booked_for_other:,
       cancellation_reason:,
+      left_campsite:,
+      left_beach:,
     ))
   }
 
@@ -1905,7 +1945,9 @@ SELECT b.id,
     b.phone_number,
     b.participant_count,
     b.booked_for_other,
-    b.cancellation_reason
+    b.cancellation_reason,
+    b.left_campsite,
+    b.left_beach
 FROM booking b
     LEFT JOIN scout_group sg ON sg.id = b.booker_group_id
 WHERE b.activity_id = $1
@@ -1941,6 +1983,8 @@ pub type GetBookingsByUserRow {
     participant_count: Int,
     booked_for_other: Bool,
     cancellation_reason: Option(String),
+    left_campsite: Bool,
+    left_beach: Bool,
   )
 }
 
@@ -1969,6 +2013,8 @@ pub fn get_bookings_by_user(
     use participant_count <- decode.field(9, decode.int)
     use booked_for_other <- decode.field(10, decode.bool)
     use cancellation_reason <- decode.field(11, decode.optional(decode.string))
+    use left_campsite <- decode.field(12, decode.bool)
+    use left_beach <- decode.field(13, decode.bool)
     decode.success(GetBookingsByUserRow(
       id:,
       user_id:,
@@ -1982,6 +2028,8 @@ pub fn get_bookings_by_user(
       participant_count:,
       booked_for_other:,
       cancellation_reason:,
+      left_campsite:,
+      left_beach:,
     ))
   }
 
@@ -2000,7 +2048,9 @@ SELECT b.id,
     b.phone_number,
     b.participant_count,
     b.booked_for_other,
-    b.cancellation_reason
+    b.cancellation_reason,
+    b.left_campsite,
+    b.left_beach
 FROM booking b
     LEFT JOIN scout_group sg ON sg.id = b.booker_group_id
 WHERE b.user_id = $1
@@ -2378,10 +2428,9 @@ SELECT $1, unnest($2::uuid[]);
 "
   |> pog.query
   |> pog.parameter(pog.text(uuid.to_string(arg_1)))
-  |> pog.parameter(pog.array(
-    fn(value) { pog.text(uuid.to_string(value)) },
-    arg_2,
-  ))
+  |> pog.parameter(
+    pog.array(fn(value) { pog.text(uuid.to_string(value)) }, arg_2),
+  )
   |> pog.returning(decoder)
   |> pog.execute(db)
 }
@@ -2433,10 +2482,9 @@ SELECT $1, unnest($2::uuid[]);
 "
   |> pog.query
   |> pog.parameter(pog.text(uuid.to_string(arg_1)))
-  |> pog.parameter(pog.array(
-    fn(value) { pog.text(uuid.to_string(value)) },
-    arg_2,
-  ))
+  |> pog.parameter(
+    pog.array(fn(value) { pog.text(uuid.to_string(value)) }, arg_2),
+  )
   |> pog.returning(decoder)
   |> pog.execute(db)
 }
@@ -3479,6 +3527,8 @@ pub type RestoreBookingRow {
     participant_count: Int,
     booked_for_other: Bool,
     cancellation_reason: Option(String),
+    left_campsite: Bool,
+    left_beach: Bool,
   )
 }
 
@@ -3506,6 +3556,8 @@ pub fn restore_booking(
     use participant_count <- decode.field(9, decode.int)
     use booked_for_other <- decode.field(10, decode.bool)
     use cancellation_reason <- decode.field(11, decode.optional(decode.string))
+    use left_campsite <- decode.field(12, decode.bool)
+    use left_beach <- decode.field(13, decode.bool)
     decode.success(RestoreBookingRow(
       id:,
       user_id:,
@@ -3519,6 +3571,8 @@ pub fn restore_booking(
       participant_count:,
       booked_for_other:,
       cancellation_reason:,
+      left_campsite:,
+      left_beach:,
     ))
   }
 
@@ -3539,7 +3593,9 @@ WITH restored AS (
         phone_number,
         participant_count,
         booked_for_other,
-        cancellation_reason
+        cancellation_reason,
+        left_campsite,
+        left_beach
 )
 SELECT r.id,
     r.user_id,
@@ -3552,7 +3608,9 @@ SELECT r.id,
     r.phone_number,
     r.participant_count,
     r.booked_for_other,
-    r.cancellation_reason
+    r.cancellation_reason,
+    r.left_campsite,
+    r.left_beach
 FROM restored r
     LEFT JOIN scout_group sg ON sg.id = r.booker_group_id
 "
@@ -3617,10 +3675,9 @@ WHERE target_group NOT IN (
 "
   |> pog.query
   |> pog.parameter(pog.text(uuid.to_string(activity_id)))
-  |> pog.parameter(pog.array(
-    fn(value) { pog.text(uuid.to_string(value)) },
-    arg_2,
-  ))
+  |> pog.parameter(
+    pog.array(fn(value) { pog.text(uuid.to_string(value)) }, arg_2),
+  )
   |> pog.parameter(pog.array(fn(value) { target_group_encoder(value) }, arg_3))
   |> pog.returning(decoder)
   |> pog.execute(db)
@@ -3755,6 +3812,242 @@ WHERE id = $1
   |> pog.execute(db)
 }
 
+/// A row you get from running the `set_booking_left_beach` query
+/// defined in `./src/server/sql/set_booking_left_beach.sql`.
+///
+/// > 🐿️ This type definition was generated automatically using v4.7.0 of the
+/// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub type SetBookingLeftBeachRow {
+  SetBookingLeftBeachRow(
+    id: Uuid,
+    user_id: Uuid,
+    activity_id: Uuid,
+    booker_name: String,
+    booker_group_id: Option(Int),
+    booker_group_name: String,
+    group_free_text: String,
+    responsible_name: String,
+    phone_number: String,
+    participant_count: Int,
+    booked_for_other: Bool,
+    cancellation_reason: Option(String),
+    left_campsite: Bool,
+    left_beach: Bool,
+  )
+}
+
+/// Tick (or untick) the badbuss "left the beach" check-off on one booking. The
+/// sibling of set_booking_left_campsite — see that file for why each stage gets
+/// its own single-column write.
+///
+/// > 🐿️ This function was generated automatically using v4.7.0 of
+/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub fn set_booking_left_beach(
+  db: pog.Connection,
+  id: Uuid,
+  left_beach: Bool,
+) -> Result(pog.Returned(SetBookingLeftBeachRow), pog.QueryError) {
+  let decoder = {
+    use id <- decode.field(0, uuid_decoder())
+    use user_id <- decode.field(1, uuid_decoder())
+    use activity_id <- decode.field(2, uuid_decoder())
+    use booker_name <- decode.field(3, decode.string)
+    use booker_group_id <- decode.field(4, decode.optional(decode.int))
+    use booker_group_name <- decode.field(5, decode.string)
+    use group_free_text <- decode.field(6, decode.string)
+    use responsible_name <- decode.field(7, decode.string)
+    use phone_number <- decode.field(8, decode.string)
+    use participant_count <- decode.field(9, decode.int)
+    use booked_for_other <- decode.field(10, decode.bool)
+    use cancellation_reason <- decode.field(11, decode.optional(decode.string))
+    use left_campsite <- decode.field(12, decode.bool)
+    use left_beach <- decode.field(13, decode.bool)
+    decode.success(SetBookingLeftBeachRow(
+      id:,
+      user_id:,
+      activity_id:,
+      booker_name:,
+      booker_group_id:,
+      booker_group_name:,
+      group_free_text:,
+      responsible_name:,
+      phone_number:,
+      participant_count:,
+      booked_for_other:,
+      cancellation_reason:,
+      left_campsite:,
+      left_beach:,
+    ))
+  }
+
+  "-- Tick (or untick) the badbuss \"left the beach\" check-off on one booking. The
+-- sibling of set_booking_left_campsite — see that file for why each stage gets
+-- its own single-column write.
+WITH ticked AS (
+    UPDATE booking
+    SET left_beach = $2
+    WHERE id = $1
+    RETURNING id,
+        user_id,
+        activity_id,
+        booker_name,
+        booker_group_id,
+        group_free_text,
+        responsible_name,
+        phone_number,
+        participant_count,
+        booked_for_other,
+        cancellation_reason,
+        left_campsite,
+        left_beach
+)
+SELECT t.id,
+    t.user_id,
+    t.activity_id,
+    t.booker_name,
+    t.booker_group_id,
+    COALESCE(sg.name, 'Kår ' || t.booker_group_id, '') AS booker_group_name,
+    t.group_free_text,
+    t.responsible_name,
+    t.phone_number,
+    t.participant_count,
+    t.booked_for_other,
+    t.cancellation_reason,
+    t.left_campsite,
+    t.left_beach
+FROM ticked t
+    LEFT JOIN scout_group sg ON sg.id = t.booker_group_id
+"
+  |> pog.query
+  |> pog.parameter(pog.text(uuid.to_string(id)))
+  |> pog.parameter(pog.bool(left_beach))
+  |> pog.returning(decoder)
+  |> pog.execute(db)
+}
+
+/// A row you get from running the `set_booking_left_campsite` query
+/// defined in `./src/server/sql/set_booking_left_campsite.sql`.
+///
+/// > 🐿️ This type definition was generated automatically using v4.7.0 of the
+/// > [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub type SetBookingLeftCampsiteRow {
+  SetBookingLeftCampsiteRow(
+    id: Uuid,
+    user_id: Uuid,
+    activity_id: Uuid,
+    booker_name: String,
+    booker_group_id: Option(Int),
+    booker_group_name: String,
+    group_free_text: String,
+    responsible_name: String,
+    phone_number: String,
+    participant_count: Int,
+    booked_for_other: Bool,
+    cancellation_reason: Option(String),
+    left_campsite: Bool,
+    left_beach: Bool,
+  )
+}
+
+/// Tick (or untick) the badbuss "left the campsite" check-off on one booking.
+/// Deliberately writes only its own flag so two staff members ticking the two
+/// stages of the same booking at once cannot overwrite each other (the second
+/// write would otherwise carry a stale value for the first's flag). The handler
+/// refuses the write unless the booking's activity is a beach-bus slot. The
+/// booker's kår name is derived by joining scout_group on the returned booking.
+///
+/// > 🐿️ This function was generated automatically using v4.7.0 of
+/// > the [squirrel package](https://github.com/giacomocavalieri/squirrel).
+///
+pub fn set_booking_left_campsite(
+  db: pog.Connection,
+  id: Uuid,
+  left_campsite: Bool,
+) -> Result(pog.Returned(SetBookingLeftCampsiteRow), pog.QueryError) {
+  let decoder = {
+    use id <- decode.field(0, uuid_decoder())
+    use user_id <- decode.field(1, uuid_decoder())
+    use activity_id <- decode.field(2, uuid_decoder())
+    use booker_name <- decode.field(3, decode.string)
+    use booker_group_id <- decode.field(4, decode.optional(decode.int))
+    use booker_group_name <- decode.field(5, decode.string)
+    use group_free_text <- decode.field(6, decode.string)
+    use responsible_name <- decode.field(7, decode.string)
+    use phone_number <- decode.field(8, decode.string)
+    use participant_count <- decode.field(9, decode.int)
+    use booked_for_other <- decode.field(10, decode.bool)
+    use cancellation_reason <- decode.field(11, decode.optional(decode.string))
+    use left_campsite <- decode.field(12, decode.bool)
+    use left_beach <- decode.field(13, decode.bool)
+    decode.success(SetBookingLeftCampsiteRow(
+      id:,
+      user_id:,
+      activity_id:,
+      booker_name:,
+      booker_group_id:,
+      booker_group_name:,
+      group_free_text:,
+      responsible_name:,
+      phone_number:,
+      participant_count:,
+      booked_for_other:,
+      cancellation_reason:,
+      left_campsite:,
+      left_beach:,
+    ))
+  }
+
+  "-- Tick (or untick) the badbuss \"left the campsite\" check-off on one booking.
+-- Deliberately writes only its own flag so two staff members ticking the two
+-- stages of the same booking at once cannot overwrite each other (the second
+-- write would otherwise carry a stale value for the first's flag). The handler
+-- refuses the write unless the booking's activity is a beach-bus slot. The
+-- booker's kår name is derived by joining scout_group on the returned booking.
+WITH ticked AS (
+    UPDATE booking
+    SET left_campsite = $2
+    WHERE id = $1
+    RETURNING id,
+        user_id,
+        activity_id,
+        booker_name,
+        booker_group_id,
+        group_free_text,
+        responsible_name,
+        phone_number,
+        participant_count,
+        booked_for_other,
+        cancellation_reason,
+        left_campsite,
+        left_beach
+)
+SELECT t.id,
+    t.user_id,
+    t.activity_id,
+    t.booker_name,
+    t.booker_group_id,
+    COALESCE(sg.name, 'Kår ' || t.booker_group_id, '') AS booker_group_name,
+    t.group_free_text,
+    t.responsible_name,
+    t.phone_number,
+    t.participant_count,
+    t.booked_for_other,
+    t.cancellation_reason,
+    t.left_campsite,
+    t.left_beach
+FROM ticked t
+    LEFT JOIN scout_group sg ON sg.id = t.booker_group_id
+"
+  |> pog.query
+  |> pog.parameter(pog.text(uuid.to_string(id)))
+  |> pog.parameter(pog.bool(left_campsite))
+  |> pog.returning(decoder)
+  |> pog.execute(db)
+}
+
 /// Point every slot of a recurring activity kind at the same location. The
 /// kind-wide counterpart of set_activity_location (a separate query from the
 /// bulk text update because squirrel parameters cannot be optional).
@@ -3846,6 +4139,7 @@ pub type UpdateActivityWithMaxAttendeesRow {
     end_time: Timestamp,
     location_id: Option(Uuid),
     booking_opens_at: Option(Timestamp),
+    recurring_activity_kind: Option(String),
   )
 }
 
@@ -3880,6 +4174,10 @@ pub fn update_activity_with_max_attendees(
       9,
       decode.optional(pog.timestamp_decoder()),
     )
+    use recurring_activity_kind <- decode.field(
+      10,
+      decode.optional(decode.string),
+    )
     decode.success(UpdateActivityWithMaxAttendeesRow(
       id:,
       title:,
@@ -3891,6 +4189,7 @@ pub fn update_activity_with_max_attendees(
       end_time:,
       location_id:,
       booking_opens_at:,
+      recurring_activity_kind:,
     ))
   }
 
@@ -3912,7 +4211,9 @@ RETURNING id,
     start_time,
     end_time,
     location_id,
-    booking_opens_at"
+    booking_opens_at,
+    recurring_activity_kind
+"
   |> pog.query
   |> pog.parameter(pog.text(uuid.to_string(id)))
   |> pog.parameter(pog.text(arg_2))
@@ -3943,6 +4244,7 @@ pub type UpdateActivityWithoutMaxAttendeesRow {
     end_time: Timestamp,
     location_id: Option(Uuid),
     booking_opens_at: Option(Timestamp),
+    recurring_activity_kind: Option(String),
   )
 }
 
@@ -3975,6 +4277,10 @@ pub fn update_activity_without_max_attendees(
       8,
       decode.optional(pog.timestamp_decoder()),
     )
+    use recurring_activity_kind <- decode.field(
+      9,
+      decode.optional(decode.string),
+    )
     decode.success(UpdateActivityWithoutMaxAttendeesRow(
       id:,
       title:,
@@ -3985,6 +4291,7 @@ pub fn update_activity_without_max_attendees(
       end_time:,
       location_id:,
       booking_opens_at:,
+      recurring_activity_kind:,
     ))
   }
 
@@ -4005,7 +4312,9 @@ RETURNING id,
     start_time,
     end_time,
     location_id,
-    booking_opens_at"
+    booking_opens_at,
+    recurring_activity_kind
+"
   |> pog.query
   |> pog.parameter(pog.text(uuid.to_string(id)))
   |> pog.parameter(pog.text(arg_2))
@@ -4038,6 +4347,8 @@ pub type UpdateBookingRow {
     participant_count: Int,
     booked_for_other: Bool,
     cancellation_reason: Option(String),
+    left_campsite: Bool,
+    left_beach: Bool,
   )
 }
 
@@ -4070,6 +4381,8 @@ pub fn update_booking(
     use participant_count <- decode.field(9, decode.int)
     use booked_for_other <- decode.field(10, decode.bool)
     use cancellation_reason <- decode.field(11, decode.optional(decode.string))
+    use left_campsite <- decode.field(12, decode.bool)
+    use left_beach <- decode.field(13, decode.bool)
     decode.success(UpdateBookingRow(
       id:,
       user_id:,
@@ -4083,6 +4396,8 @@ pub fn update_booking(
       participant_count:,
       booked_for_other:,
       cancellation_reason:,
+      left_campsite:,
+      left_beach:,
     ))
   }
 
@@ -4107,7 +4422,9 @@ WITH updated AS (
         phone_number,
         participant_count,
         booked_for_other,
-        cancellation_reason
+        cancellation_reason,
+        left_campsite,
+        left_beach
 )
 SELECT u.id,
     u.user_id,
@@ -4120,7 +4437,9 @@ SELECT u.id,
     u.phone_number,
     u.participant_count,
     u.booked_for_other,
-    u.cancellation_reason
+    u.cancellation_reason,
+    u.left_campsite,
+    u.left_beach
 FROM updated u
     LEFT JOIN scout_group sg ON sg.id = u.booker_group_id
 "

--- a/server/src/server/sql.gleam
+++ b/server/src/server/sql.gleam
@@ -2428,9 +2428,10 @@ SELECT $1, unnest($2::uuid[]);
 "
   |> pog.query
   |> pog.parameter(pog.text(uuid.to_string(arg_1)))
-  |> pog.parameter(
-    pog.array(fn(value) { pog.text(uuid.to_string(value)) }, arg_2),
-  )
+  |> pog.parameter(pog.array(
+    fn(value) { pog.text(uuid.to_string(value)) },
+    arg_2,
+  ))
   |> pog.returning(decoder)
   |> pog.execute(db)
 }
@@ -2482,9 +2483,10 @@ SELECT $1, unnest($2::uuid[]);
 "
   |> pog.query
   |> pog.parameter(pog.text(uuid.to_string(arg_1)))
-  |> pog.parameter(
-    pog.array(fn(value) { pog.text(uuid.to_string(value)) }, arg_2),
-  )
+  |> pog.parameter(pog.array(
+    fn(value) { pog.text(uuid.to_string(value)) },
+    arg_2,
+  ))
   |> pog.returning(decoder)
   |> pog.execute(db)
 }
@@ -3675,9 +3677,10 @@ WHERE target_group NOT IN (
 "
   |> pog.query
   |> pog.parameter(pog.text(uuid.to_string(activity_id)))
-  |> pog.parameter(
-    pog.array(fn(value) { pog.text(uuid.to_string(value)) }, arg_2),
-  )
+  |> pog.parameter(pog.array(
+    fn(value) { pog.text(uuid.to_string(value)) },
+    arg_2,
+  ))
   |> pog.parameter(pog.array(fn(value) { target_group_encoder(value) }, arg_3))
   |> pog.returning(decoder)
   |> pog.execute(db)

--- a/server/src/server/sql/cancel_booking.sql
+++ b/server/src/server/sql/cancel_booking.sql
@@ -17,7 +17,9 @@ WITH cancelled AS (
         phone_number,
         participant_count,
         booked_for_other,
-        cancellation_reason
+        cancellation_reason,
+        left_campsite,
+        left_beach
 )
 SELECT c.id,
     c.user_id,
@@ -30,6 +32,8 @@ SELECT c.id,
     c.phone_number,
     c.participant_count,
     c.booked_for_other,
-    c.cancellation_reason
+    c.cancellation_reason,
+    c.left_campsite,
+    c.left_beach
 FROM cancelled c
     LEFT JOIN scout_group sg ON sg.id = c.booker_group_id

--- a/server/src/server/sql/create_activity_with_max_attendees.sql
+++ b/server/src/server/sql/create_activity_with_max_attendees.sql
@@ -18,4 +18,5 @@ RETURNING id,
     start_time,
     end_time,
     location_id,
-    booking_opens_at
+    booking_opens_at,
+    recurring_activity_kind

--- a/server/src/server/sql/create_activity_without_max_attendees.sql
+++ b/server/src/server/sql/create_activity_without_max_attendees.sql
@@ -17,4 +17,5 @@ RETURNING id,
     start_time,
     end_time,
     location_id,
-    booking_opens_at
+    booking_opens_at,
+    recurring_activity_kind

--- a/server/src/server/sql/get_booking.sql
+++ b/server/src/server/sql/get_booking.sql
@@ -13,7 +13,9 @@ SELECT b.id,
     b.phone_number,
     b.participant_count,
     b.booked_for_other,
-    b.cancellation_reason
+    b.cancellation_reason,
+    b.left_campsite,
+    b.left_beach
 FROM booking b
     LEFT JOIN scout_group sg ON sg.id = b.booker_group_id
 WHERE b.id = $1

--- a/server/src/server/sql/get_bookings_by_activity.sql
+++ b/server/src/server/sql/get_bookings_by_activity.sql
@@ -13,7 +13,9 @@ SELECT b.id,
     b.phone_number,
     b.participant_count,
     b.booked_for_other,
-    b.cancellation_reason
+    b.cancellation_reason,
+    b.left_campsite,
+    b.left_beach
 FROM booking b
     LEFT JOIN scout_group sg ON sg.id = b.booker_group_id
 WHERE b.activity_id = $1

--- a/server/src/server/sql/get_bookings_by_user.sql
+++ b/server/src/server/sql/get_bookings_by_user.sql
@@ -13,7 +13,9 @@ SELECT b.id,
     b.phone_number,
     b.participant_count,
     b.booked_for_other,
-    b.cancellation_reason
+    b.cancellation_reason,
+    b.left_campsite,
+    b.left_beach
 FROM booking b
     LEFT JOIN scout_group sg ON sg.id = b.booker_group_id
 WHERE b.user_id = $1

--- a/server/src/server/sql/restore_booking.sql
+++ b/server/src/server/sql/restore_booking.sql
@@ -15,7 +15,9 @@ WITH restored AS (
         phone_number,
         participant_count,
         booked_for_other,
-        cancellation_reason
+        cancellation_reason,
+        left_campsite,
+        left_beach
 )
 SELECT r.id,
     r.user_id,
@@ -28,6 +30,8 @@ SELECT r.id,
     r.phone_number,
     r.participant_count,
     r.booked_for_other,
-    r.cancellation_reason
+    r.cancellation_reason,
+    r.left_campsite,
+    r.left_beach
 FROM restored r
     LEFT JOIN scout_group sg ON sg.id = r.booker_group_id

--- a/server/src/server/sql/set_booking_left_beach.sql
+++ b/server/src/server/sql/set_booking_left_beach.sql
@@ -1,0 +1,37 @@
+-- Tick (or untick) the badbuss "left the beach" check-off on one booking. The
+-- sibling of set_booking_left_campsite — see that file for why each stage gets
+-- its own single-column write.
+WITH ticked AS (
+    UPDATE booking
+    SET left_beach = $2
+    WHERE id = $1
+    RETURNING id,
+        user_id,
+        activity_id,
+        booker_name,
+        booker_group_id,
+        group_free_text,
+        responsible_name,
+        phone_number,
+        participant_count,
+        booked_for_other,
+        cancellation_reason,
+        left_campsite,
+        left_beach
+)
+SELECT t.id,
+    t.user_id,
+    t.activity_id,
+    t.booker_name,
+    t.booker_group_id,
+    COALESCE(sg.name, 'Kår ' || t.booker_group_id, '') AS booker_group_name,
+    t.group_free_text,
+    t.responsible_name,
+    t.phone_number,
+    t.participant_count,
+    t.booked_for_other,
+    t.cancellation_reason,
+    t.left_campsite,
+    t.left_beach
+FROM ticked t
+    LEFT JOIN scout_group sg ON sg.id = t.booker_group_id

--- a/server/src/server/sql/set_booking_left_campsite.sql
+++ b/server/src/server/sql/set_booking_left_campsite.sql
@@ -1,0 +1,40 @@
+-- Tick (or untick) the badbuss "left the campsite" check-off on one booking.
+-- Deliberately writes only its own flag so two staff members ticking the two
+-- stages of the same booking at once cannot overwrite each other (the second
+-- write would otherwise carry a stale value for the first's flag). The handler
+-- refuses the write unless the booking's activity is a beach-bus slot. The
+-- booker's kår name is derived by joining scout_group on the returned booking.
+WITH ticked AS (
+    UPDATE booking
+    SET left_campsite = $2
+    WHERE id = $1
+    RETURNING id,
+        user_id,
+        activity_id,
+        booker_name,
+        booker_group_id,
+        group_free_text,
+        responsible_name,
+        phone_number,
+        participant_count,
+        booked_for_other,
+        cancellation_reason,
+        left_campsite,
+        left_beach
+)
+SELECT t.id,
+    t.user_id,
+    t.activity_id,
+    t.booker_name,
+    t.booker_group_id,
+    COALESCE(sg.name, 'Kår ' || t.booker_group_id, '') AS booker_group_name,
+    t.group_free_text,
+    t.responsible_name,
+    t.phone_number,
+    t.participant_count,
+    t.booked_for_other,
+    t.cancellation_reason,
+    t.left_campsite,
+    t.left_beach
+FROM ticked t
+    LEFT JOIN scout_group sg ON sg.id = t.booker_group_id

--- a/server/src/server/sql/update_activity_with_max_attendees.sql
+++ b/server/src/server/sql/update_activity_with_max_attendees.sql
@@ -16,4 +16,5 @@ RETURNING id,
     start_time,
     end_time,
     location_id,
-    booking_opens_at
+    booking_opens_at,
+    recurring_activity_kind

--- a/server/src/server/sql/update_activity_without_max_attendees.sql
+++ b/server/src/server/sql/update_activity_without_max_attendees.sql
@@ -15,4 +15,5 @@ RETURNING id,
     start_time,
     end_time,
     location_id,
-    booking_opens_at
+    booking_opens_at,
+    recurring_activity_kind

--- a/server/src/server/sql/update_booking.sql
+++ b/server/src/server/sql/update_booking.sql
@@ -19,7 +19,9 @@ WITH updated AS (
         phone_number,
         participant_count,
         booked_for_other,
-        cancellation_reason
+        cancellation_reason,
+        left_campsite,
+        left_beach
 )
 SELECT u.id,
     u.user_id,
@@ -32,6 +34,8 @@ SELECT u.id,
     u.phone_number,
     u.participant_count,
     u.booked_for_other,
-    u.cancellation_reason
+    u.cancellation_reason,
+    u.left_campsite,
+    u.left_beach
 FROM updated u
     LEFT JOIN scout_group sg ON sg.id = u.booker_group_id

--- a/server/src/server/web/activities.gleam
+++ b/server/src/server/web/activities.gleam
@@ -855,24 +855,6 @@ pub fn update(req: Request, id: String, ctx: web.Context) -> Response {
 
 // --- Bulk edit of recurring activities ---------------------------------------
 
-/// A recurring activity kind — the two special multi-slot activities (badbuss
-/// and klättervägg) whose slots share title/description/location. Each kind
-/// has its own list route (`/api/beach-bus-activities`,
-/// `/api/climbing-wall-activities`), which also accepts the bulk-edit PUT, so
-/// the kind arrives typed from the router; the strings match the
-/// `activity.recurring_activity_kind` column values.
-type RecurringActivityKind {
-  BeachBus
-  ClimbingWall
-}
-
-fn recurring_activity_kind_to_sql(kind: RecurringActivityKind) -> String {
-  case kind {
-    BeachBus -> "beach-bus"
-    ClimbingWall -> "climbing-wall"
-  }
-}
-
 /// The shared fields a bulk edit applies to every slot of a recurring kind —
 /// exactly the fields the slots duplicate. Per-slot fields (times, capacity,
 /// tags, målgrupp, booking window) are deliberately absent.
@@ -918,12 +900,12 @@ fn write_recurring_activities_location(
 
 /// `PUT /api/beach-bus-activities` — bulk edit every beach bus slot.
 pub fn update_beach_bus(req: Request, ctx: web.Context) -> Response {
-  update_recurring(req, BeachBus, ctx)
+  update_recurring(req, model.BeachBus, ctx)
 }
 
 /// `PUT /api/climbing-wall-activities` — bulk edit every climbing wall slot.
 pub fn update_climbing_wall(req: Request, ctx: web.Context) -> Response {
-  update_recurring(req, ClimbingWall, ctx)
+  update_recurring(req, model.ClimbingWall, ctx)
 }
 
 /// Bulk-applies the shared fields (title, description, location) to every
@@ -933,7 +915,7 @@ pub fn update_climbing_wall(req: Request, ctx: web.Context) -> Response {
 /// which is not an error (the write is idempotent).
 fn update_recurring(
   req: Request,
-  kind: RecurringActivityKind,
+  kind: model.RecurringKind,
   ctx: web.Context,
 ) -> Response {
   use <- wisp.require_method(req, Put)
@@ -946,7 +928,7 @@ fn update_recurring(
   )
   use locations <- with_locations(ctx)
   use <- require_valid_location(locations, input.location_id)
-  let kind_sql = recurring_activity_kind_to_sql(kind)
+  let kind_sql = model.recurring_kind_to_string(kind)
   let transaction_result =
     pog.transaction(ctx.db_connection, fn(conn) {
       use updated <- result.try(sql.update_recurring_activities(

--- a/server/src/server/web/booking.gleam
+++ b/server/src/server/web/booking.gleam
@@ -618,6 +618,136 @@ pub fn cancel(req: Request, id: String, ctx: web.Context) -> Response {
   }
 }
 
+/// Which badbuss departure check-off a request targets. Each stage is written
+/// on its own so two staff members ticking the two stages of the same booking
+/// at the same time cannot overwrite each other.
+type DepartureStage {
+  LeftCampsite
+  LeftBeach
+}
+
+/// `PUT /api/bookings/:id/left-campsite` — tick/untick "left the campsite".
+pub fn set_left_campsite(
+  req: Request,
+  id: String,
+  ctx: web.Context,
+) -> Response {
+  set_departure(req, id, LeftCampsite, ctx)
+}
+
+/// `PUT /api/bookings/:id/left-beach` — tick/untick "left the beach".
+pub fn set_left_beach(req: Request, id: String, ctx: web.Context) -> Response {
+  set_departure(req, id, LeftBeach, ctx)
+}
+
+/// Shared handler for the two badbuss departure check-offs: the beach-bus staff
+/// tick off each kår as it leaves the campsite and again as it leaves the beach.
+/// Body is `{"checked": true|false}`, so the write is idempotent and a mistaken
+/// tick can be undone.
+///
+/// Open to everyone who may read the badbuss booking lists (`bookings:read` /
+/// `activities:manage` / `bookings:others:create`) — whoever runs the bus is who
+/// ticks the boxes — and deliberately NOT to the booker, who cannot read the
+/// list at all.
+///
+/// Badbuss-only: the request is refused with a 409 unless the booking's activity
+/// is a `beach-bus` slot, so the columns cannot be used as a general-purpose
+/// flag on ordinary bookings. A cancelled booking is refused too — that kår is
+/// not boarding.
+fn set_departure(
+  req: Request,
+  id: String,
+  stage: DepartureStage,
+  ctx: web.Context,
+) -> Response {
+  use <- wisp.require_method(req, Put)
+  use user <- web.with_authenticated_user(ctx)
+  use <- web.require_any_role(user, [
+    web.BookingsRead,
+    web.ActivitiesManage,
+    web.BookingsOthersCreate,
+  ])
+  use booking_id <- given.ok(uuid.from_string(id), fn(_) {
+    wisp.bad_request("Invalid booking ID format")
+  })
+  use json_body <- wisp.require_json(req)
+  use checked <- given.ok(
+    decode.run(json_body, {
+      use checked <- decode.field("checked", decode.bool)
+      decode.success(checked)
+    }),
+    fn(_) { wisp.bad_request("Invalid JSON payload") },
+  )
+
+  // Load the booking first so a missing one answers 404, then its activity so a
+  // non-badbuss booking answers 409. Both are stable facts (a booking never
+  // moves to another activity, an activity never changes kind), so no
+  // transaction is needed around the check and the write.
+  use existing <- given.ok(fetch_booking(ctx, booking_id), fn(response) {
+    response
+  })
+  use <- given.that(existing.cancellation == option.None, else_return: fn() {
+    conflict_response("Booking is cancelled")
+  })
+  use <- given.that(is_beach_bus(ctx, existing.activity_id), else_return: fn() {
+    conflict_response("Booking is not on a beach bus slot")
+  })
+
+  let written = case stage {
+    LeftCampsite ->
+      sql.set_booking_left_campsite(ctx.db_connection, booking_id, checked)
+      |> result.map(fn(returned) {
+        list.map(returned.rows, booking.from_set_booking_left_campsite_row)
+      })
+    LeftBeach ->
+      sql.set_booking_left_beach(ctx.db_connection, booking_id, checked)
+      |> result.map(fn(returned) {
+        list.map(returned.rows, booking.from_set_booking_left_beach_row)
+      })
+  }
+  case written {
+    Error(error) -> web.query_error(error)
+    Ok([]) -> wisp.not_found()
+    Ok([updated, ..]) ->
+      wisp.json_response(updated |> booking.to_json |> json.to_string, 200)
+  }
+}
+
+/// The booking being ticked off, or the response to answer with instead (404
+/// when it is gone, 500 when the query failed).
+fn fetch_booking(
+  ctx: web.Context,
+  booking_id: uuid.Uuid,
+) -> Result(Booking, Response) {
+  case sql.get_booking(ctx.db_connection, booking_id) {
+    Error(error) -> Error(web.query_error(error))
+    Ok(pog.Returned(_, [])) -> Error(wisp.not_found())
+    Ok(pog.Returned(_, [row, ..])) -> Ok(booking.from_get_booking_row(row))
+  }
+}
+
+/// Whether the activity is a slot of the badbuss (beach-bus) recurring kind.
+/// A missing activity or a failed query answers `False`, which turns into the
+/// same 409 as any other non-badbuss booking — the check only ever opens the
+/// write up, never widens it.
+fn is_beach_bus(ctx: web.Context, activity_id: uuid.Uuid) -> Bool {
+  case sql.get_activity(ctx.db_connection, activity_id) {
+    Ok(pog.Returned(_, [row, ..])) ->
+      row.recurring_activity_kind
+      == option.Some(model.recurring_kind_to_string(model.BeachBus))
+    Ok(pog.Returned(_, [])) -> False
+    Error(error) -> {
+      wisp.log_error(
+        "Beach bus check failed for activity "
+        <> uuid.to_string(activity_id)
+        <> ": "
+        <> string.inspect(error),
+      )
+      False
+    }
+  }
+}
+
 /// Restore a cancelled booking to active (issue #43): POST
 /// /api/bookings/:id/restore. Requires `bookings:others:create`. Runs the
 /// same locking transaction shape as create — a restored booking occupies

--- a/server/test/server/web/booking_test.gleam
+++ b/server/test/server/web/booking_test.gleam
@@ -1,7 +1,13 @@
+import gleam/erlang/process
+import gleam/http
+import gleam/json
 import gleam/option.{None, Some}
+import pog
 import server/web
 import server/web/booking
 import shared/model
+import wisp
+import wisp/simulate
 import youid/uuid.{type Uuid}
 
 fn parse_uuid(s: String) -> Uuid {
@@ -35,6 +41,8 @@ fn a_booking(user_id: Uuid, booked_for_other: Bool) -> model.Booking {
     participant_count: 1,
     booked_for_other:,
     cancellation: None,
+    left_campsite: False,
+    left_beach: False,
   )
 }
 
@@ -78,4 +86,121 @@ pub fn admin_manages_everything_test() {
     a_user(other_id(), [web.Admin]),
     a_booking(owner_id(), True),
   )
+}
+
+// --- Badbuss departure check-offs ------------------------------------------
+//
+// The guards these exercise (auth, role, id format, body shape) all
+// short-circuit before any query, so the unusable connection below is never
+// touched. The badbuss-only 409 and the write itself need a live database and
+// are verified against the running app instead.
+
+/// The db connection is a value-level requirement of `Context` only — see the
+/// note above.
+fn context_with_auth(auth: web.AuthenticationResult) -> web.Context {
+  web.Context(
+    static_directory: "",
+    db_connection: pog.named_connection(process.new_name("unused_db")),
+    jwt_verify_keys: web.JWTVerifyKeys("", []),
+    authentication_result: auth,
+    dev_fallback_user: None,
+    booking_opens_at: None,
+  )
+}
+
+fn a_tick() -> wisp.Request {
+  simulate.request(http.Put, "/")
+  |> simulate.json_body(json.object([#("checked", json.bool(True))]))
+}
+
+const a_booking_id = "dd000001-0000-4000-8000-000000000001"
+
+pub fn departure_check_requires_authentication_test() {
+  let response =
+    booking.set_left_campsite(
+      a_tick(),
+      a_booking_id,
+      context_with_auth(web.NotAuthenticated),
+    )
+  assert response.status == 401
+}
+
+/// A plain booker — `bookings:self:create` only — cannot tick anyone off: the
+/// check-offs belong to whoever runs the bus, and a booker cannot even read
+/// the slot's list.
+pub fn departure_check_forbidden_for_plain_booker_test() {
+  let response =
+    booking.set_left_campsite(
+      a_tick(),
+      a_booking_id,
+      context_with_auth(
+        web.Authenticated(a_user(owner_id(), [web.BookingsSelfCreate])),
+      ),
+    )
+  assert response.status == 403
+  let beach =
+    booking.set_left_beach(
+      a_tick(),
+      a_booking_id,
+      context_with_auth(
+        web.Authenticated(a_user(owner_id(), [web.BookingsSelfCreate])),
+      ),
+    )
+  assert beach.status == 403
+}
+
+/// Read access to the badbuss lists is what grants the write, so a
+/// `bookings:read` holder gets past the role guard (and is stopped by the next
+/// guard, not by 403).
+pub fn departure_check_allows_bookings_read_test() {
+  let response =
+    booking.set_left_campsite(
+      a_tick(),
+      "not-a-uuid",
+      context_with_auth(
+        web.Authenticated(a_user(owner_id(), [web.BookingsRead])),
+      ),
+    )
+  assert response.status == 400
+}
+
+pub fn departure_check_rejects_malformed_booking_id_test() {
+  let response =
+    booking.set_left_beach(
+      a_tick(),
+      "not-a-uuid",
+      context_with_auth(
+        web.Authenticated(a_user(owner_id(), [web.ActivitiesManage])),
+      ),
+    )
+  assert response.status == 400
+}
+
+/// A body without the `checked` flag is a bad request — the endpoint never
+/// guesses which way to set the box.
+pub fn departure_check_rejects_body_without_checked_test() {
+  let request =
+    simulate.request(http.Put, "/") |> simulate.json_body(json.object([]))
+  let response =
+    booking.set_left_campsite(
+      request,
+      a_booking_id,
+      context_with_auth(
+        web.Authenticated(a_user(owner_id(), [web.BookingsRead])),
+      ),
+    )
+  assert response.status == 400
+}
+
+/// Only PUT ticks a check-off.
+pub fn departure_check_rejects_other_methods_test() {
+  let response =
+    booking.set_left_campsite(
+      simulate.request(http.Post, "/"),
+      a_booking_id,
+      context_with_auth(
+        web.Authenticated(a_user(owner_id(), [web.BookingsRead])),
+      ),
+    )
+  assert response.status == 405
 }

--- a/server/test/server/web/status_test.gleam
+++ b/server/test/server/web/status_test.gleam
@@ -31,6 +31,8 @@ fn a_booking(id: String, activity_id: Uuid) -> model.Booking {
     participant_count: 1,
     booked_for_other: False,
     cancellation: None,
+    left_campsite: False,
+    left_beach: False,
   )
 }
 

--- a/shared/src/shared/model.gleam
+++ b/shared/src/shared/model.gleam
@@ -38,6 +38,11 @@ pub type Activity {
     /// seeding the form from the effective value would silently freeze the
     /// global default into an override.
     booking_opens_at_override: Option(Timestamp),
+    /// The recurring kind this activity is one slot of, `None` for an ordinary
+    /// activity. Detail-only (absent from `ActivitySummary`): the lists have no
+    /// use for it, while the bookings view needs it to tell a badbuss slot from
+    /// anything else.
+    recurring_kind: Option(RecurringKind),
   )
 }
 
@@ -90,6 +95,11 @@ pub fn activity_decoder() -> decode.Decoder(Activity) {
     None,
     decode.optional(unix_seconds_decoder()),
   )
+  use recurring_kind <- decode.optional_field(
+    "recurring_kind",
+    None,
+    decode.optional(recurring_kind_decoder()),
+  )
   case uuid.from_string(id_str) {
     Ok(id) ->
       decode.success(Activity(
@@ -105,6 +115,7 @@ pub fn activity_decoder() -> decode.Decoder(Activity) {
         cancellation:,
         booking_opens_at:,
         booking_opens_at_override:,
+        recurring_kind:,
       ))
     Error(_) ->
       decode.failure(
@@ -121,10 +132,56 @@ pub fn activity_decoder() -> decode.Decoder(Activity) {
           cancellation:,
           booking_opens_at:,
           booking_opens_at_override:,
+          recurring_kind:,
         ),
         "valid UUID string",
       )
   }
+}
+
+/// A kind of recurring activity — the two special multi-slot activities whose
+/// slots share title, description and location: badbuss (`beach-bus`) and
+/// klättervägg (`climbing-wall`). An ordinary activity has no kind.
+///
+/// The wire strings match the `activity.recurring_activity_kind` column values
+/// and the kind-specific route segments (`/api/beach-bus-activities`,
+/// `/api/beach-bus-bookings`), so the same identity serves the DB, the API and
+/// the client's overview pages.
+pub type RecurringKind {
+  BeachBus
+  ClimbingWall
+}
+
+/// The wire/DB string for a recurring kind.
+pub fn recurring_kind_to_string(kind: RecurringKind) -> String {
+  case kind {
+    BeachBus -> "beach-bus"
+    ClimbingWall -> "climbing-wall"
+  }
+}
+
+/// Parse a recurring kind from its wire/DB string. `Error(Nil)` for any other
+/// value, including the `NULL` an ordinary activity carries.
+pub fn recurring_kind_from_string(raw: String) -> Result(RecurringKind, Nil) {
+  case raw {
+    "beach-bus" -> Ok(BeachBus)
+    "climbing-wall" -> Ok(ClimbingWall)
+    _ -> Error(Nil)
+  }
+}
+
+/// Decode a recurring kind from its wire string, failing on an unknown value.
+pub fn recurring_kind_decoder() -> decode.Decoder(RecurringKind) {
+  use raw <- decode.then(decode.string)
+  case recurring_kind_from_string(raw) {
+    Ok(kind) -> decode.success(kind)
+    Error(_) -> decode.failure(BeachBus, "valid recurring activity kind")
+  }
+}
+
+/// Encode a recurring kind as its wire string.
+pub fn recurring_kind_to_json(kind: RecurringKind) -> Json {
+  kind |> recurring_kind_to_string |> json.string
 }
 
 /// Decode a timestamp sent as unix seconds, tolerating a float encoding the
@@ -487,6 +544,15 @@ pub type Booking {
     /// booking frees its spots and blocks the booker from re-booking the
     /// activity until it is restored or hard-deleted. `None` = active.
     cancellation: Option(String),
+    /// Badbuss departure check-off: the kår has left the campsite. Ticked by
+    /// the beach-bus staff on the slot's bookings view. Only meaningful — and
+    /// only settable — for a booking on a `BeachBus` slot; `False` everywhere
+    /// else. See `left_beach` for the second stage.
+    left_campsite: Bool,
+    /// Badbuss departure check-off: the kår has left the beach (the return
+    /// leg). The two stages are independent flags — ticking this one does not
+    /// require `left_campsite`, so staff can correct either in any order.
+    left_beach: Bool,
   )
 }
 
@@ -521,6 +587,12 @@ pub fn booking_decoder() -> decode.Decoder(Booking) {
     None,
     decode.optional(decode.string),
   )
+  use left_campsite <- decode.optional_field(
+    "left_campsite",
+    False,
+    decode.bool,
+  )
+  use left_beach <- decode.optional_field("left_beach", False, decode.bool)
   case
     uuid.from_string(id_str),
     uuid.from_string(user_id_str),
@@ -540,6 +612,8 @@ pub fn booking_decoder() -> decode.Decoder(Booking) {
         participant_count:,
         booked_for_other:,
         cancellation:,
+        left_campsite:,
+        left_beach:,
       ))
     _, _, _ -> {
       let dummy =
@@ -556,6 +630,8 @@ pub fn booking_decoder() -> decode.Decoder(Booking) {
           participant_count:,
           booked_for_other:,
           cancellation:,
+          left_campsite:,
+          left_beach:,
         )
       decode.failure(dummy, "valid UUID strings for id, user_id, activity_id")
     }

--- a/shared/test/shared/model_test.gleam
+++ b/shared/test/shared/model_test.gleam
@@ -72,3 +72,119 @@ pub fn location_with_integer_coordinates_decodes_test() {
   assert location.coordinates
     == Some(model.Coordinates(latitude: 56.0, longitude: 14.0))
 }
+
+// --- Recurring kind ---------------------------------------------------------
+
+/// The wire strings are the `activity.recurring_activity_kind` column values,
+/// so the round trip has to be exact in both directions.
+pub fn recurring_kind_round_trips_test() {
+  assert model.recurring_kind_to_string(model.BeachBus) == "beach-bus"
+  assert model.recurring_kind_to_string(model.ClimbingWall) == "climbing-wall"
+  assert model.recurring_kind_from_string("beach-bus") == Ok(model.BeachBus)
+  assert model.recurring_kind_from_string("climbing-wall")
+    == Ok(model.ClimbingWall)
+}
+
+pub fn unknown_recurring_kind_is_rejected_test() {
+  let assert Error(_) = model.recurring_kind_from_string("bouncy-castle")
+  let assert Error(_) = model.recurring_kind_from_string("")
+}
+
+// --- Activity.recurring_kind ------------------------------------------------
+
+/// A minimal activity body as the server serializes it, with `recurring_kind`
+/// swapped in (or left out entirely).
+fn activity_json(recurring_kind_field: String) -> String {
+  "{
+    \"id\": \"6f5e1d46-5f58-4e23-9a9d-8c2bfc2d22a0\",
+    \"title\": {\"sv\": \"Badbuss\", \"en\": \"Beach bus\"},
+    \"description\": {\"sv\": \"\", \"en\": \"\"},
+    \"max_attendees\": 50,
+    \"start_time\": 1752350400,
+    \"end_time\": 1752357600,
+    \"location\": null,
+    \"tags\": [],
+    \"target_groups\": [],
+    \"cancellation\": null,
+    " <> recurring_kind_field <> "
+    \"booking_opens_at\": null
+  }"
+}
+
+pub fn activity_recurring_kind_decodes_test() {
+  let assert Ok(activity) =
+    json.parse(
+      activity_json("\"recurring_kind\": \"beach-bus\","),
+      model.activity_decoder(),
+    )
+  assert activity.recurring_kind == Some(model.BeachBus)
+}
+
+pub fn activity_null_recurring_kind_decodes_to_none_test() {
+  let assert Ok(activity) =
+    json.parse(
+      activity_json("\"recurring_kind\": null,"),
+      model.activity_decoder(),
+    )
+  assert activity.recurring_kind == None
+}
+
+/// An older payload without the field decodes as an ordinary activity rather
+/// than failing.
+pub fn activity_absent_recurring_kind_decodes_to_none_test() {
+  let assert Ok(activity) =
+    json.parse(activity_json(""), model.activity_decoder())
+  assert activity.recurring_kind == None
+}
+
+// --- Booking departure check-offs -------------------------------------------
+
+/// A booking body as the server serializes it, with the departure fields
+/// swapped in (or left out entirely).
+fn booking_json(departure_fields: String) -> String {
+  "{
+    \"id\": \"dd000001-0000-4000-8000-000000000001\",
+    \"user_id\": \"a1b2c3d4-e5f6-4a90-abcd-ef1234567890\",
+    \"activity_id\": \"6f5e1d46-5f58-4e23-9a9d-8c2bfc2d22a0\",
+    \"booker_name\": \"Anna Svensson\",
+    \"booker_group_id\": 101,
+    \"booker_group_name\": \"Sjöscoutkåren Dansen\",
+    \"group_free_text\": \"\",
+    \"responsible_name\": \"Anna Svensson\",
+    \"phone_number\": \"+46701234567\",
+    \"participant_count\": 12,
+    \"booked_for_other\": false,
+    " <> departure_fields <> "
+    \"cancellation\": null
+  }"
+}
+
+pub fn booking_departure_flags_decode_test() {
+  let assert Ok(booking) =
+    json.parse(
+      booking_json("\"left_campsite\": true, \"left_beach\": false,"),
+      model.booking_decoder(),
+    )
+  assert booking.left_campsite
+  assert !booking.left_beach
+}
+
+/// The two stages are independent, so only the beach one being set decodes
+/// just as happily.
+pub fn booking_left_beach_alone_decodes_test() {
+  let assert Ok(booking) =
+    json.parse(
+      booking_json("\"left_campsite\": false, \"left_beach\": true,"),
+      model.booking_decoder(),
+    )
+  assert !booking.left_campsite
+  assert booking.left_beach
+}
+
+/// A payload predating the columns decodes with both boxes unticked rather than
+/// failing — the same tolerance `booked_for_other` has.
+pub fn booking_absent_departure_flags_default_to_false_test() {
+  let assert Ok(booking) = json.parse(booking_json(""), model.booking_decoder())
+  assert !booking.left_campsite
+  assert !booking.left_beach
+}


### PR DESCRIPTION
The beach bus staff account for every kår twice per slot — once when it has left the campsite and again when it has left the beach — and had nowhere to record that. Each booking on a badbuss slot now carries two checkmarks on the slot's bookings view.

Two new columns on booking, added non-destructively: both are new and NOT NULL with a constant FALSE default, so PostgreSQL fills them in from the catalog without rewriting the table and every existing booking keeps all of its current values.

One endpoint per stage (PUT /api/bookings/:id/left-campsite and .../left-beach), each writing only its own column, so two staff members ticking the two stages of one booking at once cannot overwrite each other with a stale value for the other's flag. Both are idempotent, refuse any booking that is not on a beach-bus slot (409) or that is cancelled, and are open to whoever may read the badbuss booking lists.

Telling badbuss apart client-side needed the kind on the wire, so RecurringKind moves into shared/model — replacing the client's and web/activities.gleam's private duplicates — and Activity gains a detail-only recurring_kind. ActivitySummary deliberately does not carry it, leaving every list payload and ETag unchanged.

Ticking is optimistic, since scout-checkbox owns its checked state once clicked: the response replaces the card wholesale, and a failure rolls the tick back and reports it above the list.